### PR TITLE
[chore] 개발환경 -> postgreSQL 사용하도록 설정

### DIFF
--- a/backend/src/main/java/com/back/api/queue/scheduler/QueueEntryScheduler.java
+++ b/backend/src/main/java/com/back/api/queue/scheduler/QueueEntryScheduler.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -26,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@Profile("!dev") //임시 스케줄러 차단
 public class QueueEntryScheduler {
 
 	private final QueueEntryRedisRepository queueEntryRedisRepository;

--- a/backend/src/main/java/com/back/api/queue/scheduler/QueueShuffleScheduler.java
+++ b/backend/src/main/java/com/back/api/queue/scheduler/QueueShuffleScheduler.java
@@ -3,6 +3,7 @@ package com.back.api.queue.scheduler;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@Profile("!dev") //임시 스케줄러 차단
 public class QueueShuffleScheduler {
 
 	private final QueueEntryRepository queueEntryRepository;

--- a/backend/src/main/java/com/back/domain/event/entity/Event.java
+++ b/backend/src/main/java/com/back/domain/event/entity/Event.java
@@ -11,7 +11,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -35,7 +34,7 @@ public class Event extends BaseEntity {
 	@Column(nullable = false)
 	private EventCategory category;
 
-	@Lob
+	//@Lob
 	@Column(columnDefinition = "TEXT")
 	private String description;
 

--- a/backend/src/main/java/com/back/global/init/EventDataInit.java
+++ b/backend/src/main/java/com/back/global/init/EventDataInit.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-@Profile("local")
+@Profile("dev")
 public class EventDataInit implements ApplicationRunner {
 
 	private final EventRepository eventRepository;

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -6,4 +6,4 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   config:
     import: optional:file:.env.properties
   profiles:
-    active: local
+    active: dev
   output:
     ansi:
       enabled: always


### PR DESCRIPTION
## 📌 개요
- 기존 yml local(h2)로 설정된 부분을 dev(postgreSQL) 사용하도록 변경
- 더 이상 h2-console 접근하지 않고 intellij 내부에서 db 확인 가능하도록!

---

## ✨ 작업 내용
- yml -> dev로 변경
- eventDataInit -> dev로 변경
- dev -> create-drop으로 변경
- QueueEntry 도메인 스케줄러 임시 차단(dev)
- Event 도메인 description의 @Lob 이 불필요할 거 같아서 임시 주석 처리했습니다! 추후 다시 필요하다면 복구하도록 하겠습니다!
  - PostgreSQL의 TEXT 타입은 최대 1GB까지 저장 가능
  - @Lob 없이도 충분히 긴 문자열 저장 가능


---

## 🔗 관련 이슈
- close #34

---

## 🧪 체크리스트
- [ ] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [ ] 팀 내 코드 스타일 준수
- [ ] 이슈 연결
