### PR TITLE
[refactor] Event Swagger 인터페이스 분리 및 리팩토링

### DIFF
--- a/backend/src/main/java/com/back/api/event/controller/EventApi.java
+++ b/backend/src/main/java/com/back/api/event/controller/EventApi.java
@@ -4,11 +4,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.back.api.event.dto.request.EventCreateRequest;
@@ -22,7 +19,6 @@ import com.back.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
@@ -34,9 +30,10 @@ public interface EventApi {
 	)
 	@ApiErrorCode({
 		"INVALID_EVENT_DATE",
-		"DUPLICATE_EVENT"
+		"DUPLICATE_EVENT",
+		"EVENT_ALREADY_CLOSED",
+		"PRE_REGISTER_NOT_OPEN"
 	})
-	@PostMapping
 	ApiResponse<EventResponse> createEvent(@Valid @RequestBody EventCreateRequest request);
 
 	@Operation(
@@ -46,9 +43,10 @@ public interface EventApi {
 	@ApiErrorCode({
 		"NOT_FOUND_EVENT",
 		"INVALID_EVENT_DATE",
-		"DUPLICATE_EVENT"
+		"DUPLICATE_EVENT",
+		"EVENT_ALREADY_CLOSED",
+		"PRE_REGISTER_NOT_OPEN"
 	})
-	@PutMapping("/{eventId}")
 	ApiResponse<EventResponse> updateEvent(
 		@Parameter(description = "수정할 이벤트 ID", example = "1")
 		@PathVariable Long eventId,
@@ -58,8 +56,10 @@ public interface EventApi {
 		summary = "이벤트 삭제",
 		description = "이벤트를 삭제합니다. 관리자 권한이 필요합니다."
 	)
-	@ApiErrorCode("NOT_FOUND_EVENT")
-	@DeleteMapping("/{eventId}")
+	@ApiErrorCode({
+		"NOT_FOUND_EVENT",
+		"EVENT_ALREADY_CLOSED"
+	})
 	ApiResponse<Void> deleteEvent(
 		@Parameter(description = "삭제할 이벤트 ID", example = "1")
 		@PathVariable Long eventId);
@@ -69,7 +69,6 @@ public interface EventApi {
 		description = "이벤트 ID로 상세 정보를 조회합니다. 이벤트 상세 페이지에서 사용됩니다."
 	)
 	@ApiErrorCode("NOT_FOUND_EVENT")
-	@GetMapping("/{eventId}")
 	ApiResponse<EventResponse> getEvent(
 		@Parameter(description = "조회할 이벤트 ID", example = "1")
 		@PathVariable Long eventId);
@@ -78,7 +77,6 @@ public interface EventApi {
 		summary = "이벤트 목록 조회",
 		description = "이벤트 목록을 조회합니다. 상태(status)와 카테고리(category)로 필터링할 수 있습니다."
 	)
-	@GetMapping
 	ApiResponse<Page<EventListResponse>> getEvents(
 		@Parameter(description = "이벤트 상태 필터 (미입력 시 전체 조회)", example = "PRE_OPEN")
 		@RequestParam(required = false) EventStatus status,

--- a/backend/src/main/java/com/back/api/event/controller/EventController.java
+++ b/backend/src/main/java/com/back/api/event/controller/EventController.java
@@ -22,7 +22,6 @@ import com.back.domain.event.entity.EventCategory;
 import com.back.domain.event.entity.EventStatus;
 import com.back.global.response.ApiResponse;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -33,6 +32,7 @@ public class EventController implements EventApi {
 
 	private final EventService eventService;
 
+	@Override
 	@PostMapping
 	public ApiResponse<EventResponse> createEvent(
 		@Valid @RequestBody EventCreateRequest request) {
@@ -40,38 +40,37 @@ public class EventController implements EventApi {
 		return ApiResponse.created("이벤트가 생성되었습니다.", response);
 	}
 
+	@Override
 	@PutMapping("/{eventId}")
 	public ApiResponse<EventResponse> updateEvent(
-		@Parameter(description = "수정할 이벤트 ID", example = "1", required = true)
 		@PathVariable Long eventId,
 		@Valid @RequestBody EventUpdateRequest request) {
 		EventResponse response = eventService.updateEvent(eventId, request);
 		return ApiResponse.ok("이벤트가 수정되었습니다.", response);
 	}
 
+	@Override
 	@DeleteMapping("/{eventId}")
 	public ApiResponse<Void> deleteEvent(
-		@Parameter(description = "삭제할 이벤트 ID", example = "1", required = true)
 		@PathVariable Long eventId) {
 		eventService.deleteEvent(eventId);
 		return ApiResponse.noContent("이벤트가 삭제되었습니다.");
 	}
 
+	@Override
 	@GetMapping("/{eventId}")
 	public ApiResponse<EventResponse> getEvent(
-		@Parameter(description = "조회할 이벤트 ID", example = "1", required = true)
 		@PathVariable Long eventId) {
 		EventResponse response = eventService.getEvent(eventId);
 		return ApiResponse.ok("이벤트를 조회했습니다.", response);
 	}
 
+	@Override
 	@GetMapping
 	public ApiResponse<Page<EventListResponse>> getEvents(
-		@Parameter @RequestParam(required = false) EventStatus status,
-
-		@Parameter @RequestParam(required = false) EventCategory category,
-
-		@Parameter @PageableDefault Pageable pageable) {
+		@RequestParam(required = false) EventStatus status,
+		@RequestParam(required = false) EventCategory category,
+		@PageableDefault Pageable pageable) {
 		Page<EventListResponse> response = eventService.getEvents(status, category, pageable);
 		return ApiResponse.ok("이벤트 목록을 조회했습니다.", response);
 	}


### PR DESCRIPTION
## 📌 개요
- Event Swagger 인터페이스 분리 및 리팩토링 진행

---

## ✨ 작업 내용
   - `EventApi` 인터페이스 생성 및 `EventController` 리팩토링
       - EventController에 있던 Swagger 어노테이션을 EventApi 인터페이스로 분리하여 역할과 책임을 명확히 했습니다.
       - API 명세에서 에러 관련 응답(@ApiResponses) 부분을 제외하여 간소화했습니다.


   - `EventControllerTest` 테스트 케이스 수정
       - deleteEvent API의 실제 응답 코드인 204 No Content에 맞게 테스트 기대값을 isOk()에서 isNoContent()로 변경하여, 실패하던 테스트 케이스를 수정했습니다.

---

## 🔗 관련 이슈
- close #37 

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
