### PR TITLE
[feat] PreRegister 도메인 기본 세팅

### DIFF
--- a/backend/src/main/java/com/back/api/preregister/dto/request/PreRegisterCreateRequest.java
+++ b/backend/src/main/java/com/back/api/preregister/dto/request/PreRegisterCreateRequest.java
@@ -1,0 +1,28 @@
+package com.back.api.preregister.dto.request;
+
+import java.time.LocalDate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "사전등록 생성 요청")
+public record PreRegisterCreateRequest(
+
+	@Schema(description = "이름", example = "홍길동")
+	@NotBlank(message = "이름은 필수입니다.")
+	String name,
+
+	@Schema(description = "비밀번호 (6자 이상)", example = "password123")
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	@Size(min = 6, message = "비밀번호는 6자 이상이어야 합니다.")
+	String password,
+
+	@Schema(description = "생년월일", example = "1990-01-01")
+	@NotNull(message = "생년월일은 필수입니다.")
+	@Past(message = "생년월일은 과거 날짜여야 합니다.")
+	LocalDate birthDate
+) {
+}

--- a/backend/src/main/java/com/back/api/preregister/dto/response/PreRegisterResponse.java
+++ b/backend/src/main/java/com/back/api/preregister/dto/response/PreRegisterResponse.java
@@ -1,0 +1,38 @@
+package com.back.api.preregister.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.back.domain.preregister.entity.PreRegister;
+import com.back.domain.preregister.entity.PreRegisterStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사전등록 응답")
+public record PreRegisterResponse(
+
+	@Schema(description = "사전등록 ID", example = "1")
+	Long id,
+
+	@Schema(description = "이벤트 ID", example = "1")
+	Long eventId,
+
+	@Schema(description = "사용자 ID", example = "1")
+	Long userId,
+
+	@Schema(description = "사전등록 상태", example = "REGISTERED")
+	PreRegisterStatus status,
+
+	@Schema(description = "등록일시", example = "2025-12-10T10:00:00")
+	LocalDateTime createdAt
+) {
+
+	public static PreRegisterResponse from(PreRegister preRegister) {
+		return new PreRegisterResponse(
+			preRegister.getId(),
+			preRegister.getEventId(),
+			preRegister.getUserId(),
+			preRegister.getPreRegisterStatus(),
+			preRegister.getCreateAt()
+		);
+	}
+}

--- a/backend/src/main/java/com/back/domain/preregister/entity/PreRegisterStatus.java
+++ b/backend/src/main/java/com/back/domain/preregister/entity/PreRegisterStatus.java
@@ -2,12 +2,12 @@ package com.back.domain.preregister.entity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "사전 등록 상태")
+@Schema(description = "사전등록 상태")
 public enum PreRegisterStatus {
 
-	@Schema(description = "사전 등록 완료")
+	@Schema(description = "사전등록 완료")
 	REGISTERED,
 
-	@Schema(description = "사전 등록 취소")
+	@Schema(description = "사전등록 취소")
 	CANCELED
 }

--- a/backend/src/main/java/com/back/domain/preregister/repository/PreRegisterRepository.java
+++ b/backend/src/main/java/com/back/domain/preregister/repository/PreRegisterRepository.java
@@ -1,8 +1,14 @@
 package com.back.domain.preregister.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.back.domain.preregister.entity.PreRegister;
 
 public interface PreRegisterRepository extends JpaRepository<PreRegister, Long> {
+
+	boolean existsByEvent_IdAndUser_Id(Long eventId, Long userId);
+
+	Optional<PreRegister> findByEvent_IdAndUser_Id(Long eventId, Long userId);
 }

--- a/backend/src/main/java/com/back/global/error/code/PreRegisterErrorCode.java
+++ b/backend/src/main/java/com/back/global/error/code/PreRegisterErrorCode.java
@@ -1,0 +1,25 @@
+package com.back.global.error.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PreRegisterErrorCode implements ErrorCode {
+
+	// ===== 사전등록 조회 실패 =====
+	NOT_FOUND_PRE_REGISTER(HttpStatus.NOT_FOUND, "사전등록 내역을 찾을 수 없습니다."),
+
+	// ===== 사전등록 유효성 검증 실패 =====
+	ALREADY_PRE_REGISTERED(HttpStatus.BAD_REQUEST, "이미 사전등록되어 있습니다."),
+	INVALID_USER_INFO(HttpStatus.BAD_REQUEST, "입력한 정보가 회원 정보와 일치하지 않습니다."),
+	INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+
+	// ===== 사전등록 상태 오류 =====
+	ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 사전등록입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}


### PR DESCRIPTION
## 📌 개요
- 사전등록 기능 구현을 위한 PreRegister 도메인 기본 구조를 구축

---

## ✨ 작업 내용
   - [x] PreRegisterStatus Schema 수정 (사전 등록 -> 사전등록)
   - [x] PreRegisterRepository 수정
   - [x] PreRegister 관련 ErrorCode 추가
   - [x] PreRegister API 구현을 위한 DTO 추가
---

## 🔗 관련 이슈
- close #52 

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
