### PR TITLE
[feat] PreRegister API 구현

### DIFF
--- a/backend/src/main/java/com/back/api/preregister/controller/PreRegisterApi.java
+++ b/backend/src/main/java/com/back/api/preregister/controller/PreRegisterApi.java
@@ -1,0 +1,81 @@
+package com.back.api.preregister.controller;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.back.api.preregister.dto.response.PreRegisterResponse;
+import com.back.global.config.swagger.ApiErrorCode;
+import com.back.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "PreRegister API", description = "사전등록 API")
+public interface PreRegisterApi {
+
+	@Operation(
+		summary = "사전등록",
+		description = "이벤트에 사전등록합니다. 사전등록 기간 내에만 가능하며, 1인 1회만 등록할 수 있습니다."
+	)
+	@ApiErrorCode({
+		"NOT_FOUND_EVENT",
+		"NOT_FOUND_USER",
+		"ALREADY_PRE_REGISTERED",
+		"INVALID_PRE_REGISTRATION_PERIOD"
+	})
+	ApiResponse<PreRegisterResponse> register(
+		@Parameter(description = "이벤트 ID", example = "1")
+		@PathVariable Long eventId,
+		@Parameter(description = "사용자 ID", example = "1")
+		@RequestParam Long userId
+	);
+
+	@Operation(
+		summary = "사전등록 취소",
+		description = "사전등록을 취소합니다. 이미 취소된 경우 오류가 발생합니다."
+	)
+	@ApiErrorCode({
+		"NOT_FOUND_PRE_REGISTER",
+		"ALREADY_CANCELED"
+	})
+	ApiResponse<Void> cancel(
+		@Parameter(description = "이벤트 ID", example = "1")
+		@PathVariable Long eventId,
+		@Parameter(description = "사용자 ID", example = "1")
+		@RequestParam Long userId
+	);
+
+	@Operation(
+		summary = "내 사전등록 조회",
+		description = "특정 이벤트에 대한 내 사전등록 정보를 조회합니다."
+	)
+	@ApiErrorCode("NOT_FOUND_PRE_REGISTER")
+	ApiResponse<PreRegisterResponse> getMyPreRegister(
+		@Parameter(description = "이벤트 ID", example = "1")
+		@PathVariable Long eventId,
+		@Parameter(description = "사용자 ID", example = "1")
+		@RequestParam Long userId
+	);
+
+	@Operation(
+		summary = "사전등록 현황 조회",
+		description = "특정 이벤트의 사전등록 수를 조회합니다."
+	)
+	@ApiErrorCode("NOT_FOUND_EVENT")
+	ApiResponse<Long> getRegistrationCount(
+		@Parameter(description = "이벤트 ID", example = "1")
+		@PathVariable Long eventId
+	);
+
+	@Operation(
+		summary = "사전등록 여부 확인",
+		description = "특정 이벤트에 사전등록했는지 여부를 확인합니다."
+	)
+	ApiResponse<Boolean> isRegistered(
+		@Parameter(description = "이벤트 ID", example = "1")
+		@PathVariable Long eventId,
+		@Parameter(description = "사용자 ID", example = "1")
+		@RequestParam Long userId
+	);
+}

--- a/backend/src/main/java/com/back/api/preregister/controller/PreRegisterController.java
+++ b/backend/src/main/java/com/back/api/preregister/controller/PreRegisterController.java
@@ -1,0 +1,67 @@
+package com.back.api.preregister.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.api.preregister.dto.response.PreRegisterResponse;
+import com.back.api.preregister.service.PreRegisterService;
+import com.back.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/events/{eventId}/pre-registers")
+@RequiredArgsConstructor
+public class PreRegisterController implements PreRegisterApi {
+
+	private final PreRegisterService preRegisterService;
+
+	@Override
+	@PostMapping
+	public ApiResponse<PreRegisterResponse> register(
+		@PathVariable Long eventId,
+		@RequestParam Long userId) {
+		PreRegisterResponse response = preRegisterService.register(eventId, userId);
+		return ApiResponse.created("사전등록이 완료되었습니다.", response);
+	}
+
+	@Override
+	@DeleteMapping
+	public ApiResponse<Void> cancel(
+		@PathVariable Long eventId,
+		@RequestParam Long userId) {
+		preRegisterService.cancel(eventId, userId);
+		return ApiResponse.noContent("사전등록이 취소되었습니다.");
+	}
+
+	@Override
+	@GetMapping("/me")
+	public ApiResponse<PreRegisterResponse> getMyPreRegister(
+		@PathVariable Long eventId,
+		@RequestParam Long userId) {
+		PreRegisterResponse response = preRegisterService.getMyPreRegister(eventId, userId);
+		return ApiResponse.ok("사전등록 정보를 조회했습니다.", response);
+	}
+
+	@Override
+	@GetMapping("/count")
+	public ApiResponse<Long> getRegistrationCount(
+		@PathVariable Long eventId) {
+		Long count = preRegisterService.getRegistrationCount(eventId);
+		return ApiResponse.ok("사전등록 현황을 조회했습니다.", count);
+	}
+
+	@Override
+	@GetMapping("/status")
+	public ApiResponse<Boolean> isRegistered(
+		@PathVariable Long eventId,
+		@RequestParam Long userId) {
+		Boolean isRegistered = preRegisterService.isRegistered(eventId, userId);
+		return ApiResponse.ok("사전등록 여부를 확인했습니다.", isRegistered);
+	}
+}

--- a/backend/src/main/java/com/back/api/preregister/service/PreRegisterService.java
+++ b/backend/src/main/java/com/back/api/preregister/service/PreRegisterService.java
@@ -1,0 +1,103 @@
+package com.back.api.preregister.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.api.preregister.dto.response.PreRegisterResponse;
+import com.back.domain.event.entity.Event;
+import com.back.domain.event.repository.EventRepository;
+import com.back.domain.preregister.entity.PreRegister;
+import com.back.domain.preregister.entity.PreRegisterStatus;
+import com.back.domain.preregister.repository.PreRegisterRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.error.code.CommonErrorCode;
+import com.back.global.error.code.EventErrorCode;
+import com.back.global.error.code.PreRegisterErrorCode;
+import com.back.global.error.exception.ErrorException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PreRegisterService {
+
+	private final PreRegisterRepository preRegisterRepository;
+	private final EventRepository eventRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public PreRegisterResponse register(Long eventId, Long userId) {
+		Event event = findEventById(eventId);
+		User user = findUserById(userId);
+
+		validatePreRegistrationPeriod(event);
+		validateDuplicateRegistration(eventId, userId);
+
+		PreRegister preRegister = PreRegister.builder()
+			.event(event)
+			.user(user)
+			.build();
+
+		PreRegister savedPreRegister = preRegisterRepository.save(preRegister);
+		return PreRegisterResponse.from(savedPreRegister);
+	}
+
+	@Transactional
+	public void cancel(Long eventId, Long userId) {
+		PreRegister preRegister = findPreRegister(eventId, userId);
+
+		if (preRegister.isCanceled()) {
+			throw new ErrorException(PreRegisterErrorCode.ALREADY_CANCELED);
+		}
+
+		preRegister.cancel();
+	}
+
+	public boolean isRegistered(Long eventId, Long userId) {
+		return preRegisterRepository.findByEvent_IdAndUser_Id(eventId, userId)
+			.map(PreRegister::isRegistered)
+			.orElse(false);
+	}
+
+	public PreRegisterResponse getMyPreRegister(Long eventId, Long userId) {
+		PreRegister preRegister = findPreRegister(eventId, userId);
+		return PreRegisterResponse.from(preRegister);
+	}
+
+	public Long getRegistrationCount(Long eventId) {
+		findEventById(eventId);
+		return preRegisterRepository.countByEvent_IdAndPreRegisterStatus(eventId, PreRegisterStatus.REGISTERED);
+	}
+
+	private Event findEventById(Long eventId) {
+		return eventRepository.findById(eventId)
+			.orElseThrow(() -> new ErrorException(EventErrorCode.NOT_FOUND_EVENT));
+	}
+
+	private User findUserById(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new ErrorException(CommonErrorCode.NOT_FOUND_USER));
+	}
+
+	private PreRegister findPreRegister(Long eventId, Long userId) {
+		return preRegisterRepository.findByEvent_IdAndUser_Id(eventId, userId)
+			.orElseThrow(() -> new ErrorException(PreRegisterErrorCode.NOT_FOUND_PRE_REGISTER));
+	}
+
+	private void validatePreRegistrationPeriod(Event event) {
+		LocalDateTime now = LocalDateTime.now();
+		if (now.isBefore(event.getPreOpenAt()) || now.isAfter(event.getPreCloseAt())) {
+			throw new ErrorException(PreRegisterErrorCode.INVALID_PRE_REGISTRATION_PERIOD);
+		}
+	}
+
+	private void validateDuplicateRegistration(Long eventId, Long userId) {
+		if (preRegisterRepository.existsByEvent_IdAndUser_Id(eventId, userId)) {
+			throw new ErrorException(PreRegisterErrorCode.ALREADY_PRE_REGISTERED);
+		}
+	}
+}

--- a/backend/src/main/java/com/back/domain/preregister/repository/PreRegisterRepository.java
+++ b/backend/src/main/java/com/back/domain/preregister/repository/PreRegisterRepository.java
@@ -5,10 +5,13 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.back.domain.preregister.entity.PreRegister;
+import com.back.domain.preregister.entity.PreRegisterStatus;
 
 public interface PreRegisterRepository extends JpaRepository<PreRegister, Long> {
 
 	boolean existsByEvent_IdAndUser_Id(Long eventId, Long userId);
 
 	Optional<PreRegister> findByEvent_IdAndUser_Id(Long eventId, Long userId);
+
+	Long countByEvent_IdAndPreRegisterStatus(Long eventId, PreRegisterStatus status);
 }

--- a/backend/src/main/java/com/back/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/back/global/config/SwaggerConfig.java
@@ -148,8 +148,10 @@ public class SwaggerConfig {
 			CommonErrorCode.class,
 			com.back.global.error.code.AuthErrorCode.class,
 			com.back.global.error.code.EventErrorCode.class,
+			com.back.global.error.code.PreRegisterErrorCode.class,
 			com.back.global.error.code.QueueEntryErrorCode.class,
-			com.back.global.error.code.SeatErrorCode.class
+			com.back.global.error.code.SeatErrorCode.class,
+			com.back.global.error.code.TicketErrorCode.class
 		};
 
 		for (Class<?> clazz : errorCodeClasses) {

--- a/backend/src/main/java/com/back/global/error/code/PreRegisterErrorCode.java
+++ b/backend/src/main/java/com/back/global/error/code/PreRegisterErrorCode.java
@@ -16,6 +16,7 @@ public enum PreRegisterErrorCode implements ErrorCode {
 	ALREADY_PRE_REGISTERED(HttpStatus.BAD_REQUEST, "이미 사전등록되어 있습니다."),
 	INVALID_USER_INFO(HttpStatus.BAD_REQUEST, "입력한 정보가 회원 정보와 일치하지 않습니다."),
 	INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+	INVALID_PRE_REGISTRATION_PERIOD(HttpStatus.BAD_REQUEST, "사전등록 기간이 아닙니다."),
 
 	// ===== 사전등록 상태 오류 =====
 	ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 사전등록입니다.");

--- a/backend/src/test/rest/event.http
+++ b/backend/src/test/rest/event.http
@@ -1,0 +1,65 @@
+@BASE_URL = http://localhost:8080
+@EVENT_ID = 1
+
+### 이벤트 생성
+POST {{BASE_URL}}/api/v1/events
+Content-Type: application/json
+
+{
+  "title": "2025 서울 뮤직 페스티벌",
+  "category": "CONCERT",
+  "description": "세계 최고의 아티스트들이 모이는 뮤직 페스티벌입니다.",
+  "place": "잠실 올림픽 주경기장",
+  "imageUrl": "https://example.com/images/event1.jpg",
+  "minPrice": 30000,
+  "maxPrice": 150000,
+  "preOpenAt": "2026-01-15T10:00:00",
+  "preCloseAt": "2026-01-20T23:59:59",
+  "ticketOpenAt": "2026-01-25T10:00:00",
+  "ticketCloseAt": "2026-01-30T23:59:59",
+  "maxTicketAmount": 5000
+}
+
+> {%
+    if (response.body && response.body.data) {
+        client.global.set("EVENT_ID", response.body.data.id);
+    }
+%}
+
+### 이벤트 단건 조회
+GET {{BASE_URL}}/api/v1/events/{{EVENT_ID}}
+
+### 이벤트 목록 조회 (전체)
+GET {{BASE_URL}}/api/v1/events?page=0&size=10
+
+### 이벤트 목록 조회 (상태 필터)
+GET {{BASE_URL}}/api/v1/events?status=READY&page=0&size=10
+
+### 이벤트 목록 조회 (카테고리 필터)
+GET {{BASE_URL}}/api/v1/events?category=CONCERT&page=0&size=10
+
+### 이벤트 목록 조회 (상태 + 카테고리 필터)
+GET {{BASE_URL}}/api/v1/events?status=READY&category=CONCERT&page=0&size=10
+
+### 이벤트 수정
+PUT {{BASE_URL}}/api/v1/events/{{EVENT_ID}}
+Content-Type: application/json
+
+{
+  "title": "2025 서울 뮤직 페스티벌 (업데이트)",
+  "category": "CONCERT",
+  "description": "세계 최고의 아티스트들이 모이는 뮤직 페스티벌입니다. 라인업 업데이트!",
+  "place": "잠실 올림픽 주경기장",
+  "imageUrl": "https://example.com/images/event1_updated.jpg",
+  "minPrice": 40000,
+  "maxPrice": 180000,
+  "preOpenAt": "2026-01-15T10:00:00",
+  "preCloseAt": "2026-01-20T23:59:59",
+  "ticketOpenAt": "2026-01-25T10:00:00",
+  "ticketCloseAt": "2026-01-30T23:59:59",
+  "maxTicketAmount": 6000,
+  "status": "PRE_OPEN"
+}
+
+### 이벤트 삭제
+DELETE {{BASE_URL}}/api/v1/events/{{EVENT_ID}}

--- a/backend/src/test/rest/preregister.http
+++ b/backend/src/test/rest/preregister.http
@@ -1,0 +1,23 @@
+@BASE_URL = http://localhost:8080
+@EVENT_ID = 1
+
+### 사전등록
+POST {{BASE_URL}}/api/v1/events/{{EVENT_ID}}/pre-registers?userId=1
+
+> {%
+    if (response.body && response.body.data) {
+        client.global.set("PRE_REGISTER_ID", response.body.data.id);
+    }
+%}
+
+### 내 사전등록 조회
+GET {{BASE_URL}}/api/v1/events/{{EVENT_ID}}/pre-registers/me?userId=1
+
+### 사전등록 여부 확인
+GET {{BASE_URL}}/api/v1/events/{{EVENT_ID}}/pre-registers/status?userId=1
+
+### 사전등록 현황 조회 (전체 수)
+GET {{BASE_URL}}/api/v1/events/{{EVENT_ID}}/pre-registers/count
+
+### 사전등록 취소
+DELETE {{BASE_URL}}/api/v1/events/{{EVENT_ID}}/pre-registers?userId=1


### PR DESCRIPTION
## 📌 개요
- PreRegister 도메인을 기반으로 사용자가 이벤트에 사전등록 / 취소 / 조회를 수행할 수 있는 API를 구현

---

## ✨ 작업 내용
- PreRegisterService 구현
- PreRegisterController 구현
- PreRegisterApi Swagger 문서 작성
- http(event, preregister) 작성
- PreRegister Repository 및 ErrorCode 수정
- SwaggerConfig 배열에 PreRegisterErrorCode 추가

---

## 🔗 관련 이슈
- close #57 

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
