### PR TITLE
[feat] 사용자 프로필 조회 기능 추가

### DIFF
--- a/backend/src/main/java/com/back/api/user/controller/UserApi.java
+++ b/backend/src/main/java/com/back/api/user/controller/UserApi.java
@@ -1,0 +1,21 @@
+package com.back.api.user.controller;
+
+import com.back.api.user.dto.response.UserProfileResponse;
+import com.back.global.config.swagger.ApiErrorCode;
+import com.back.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "User API", description = "사용자 정보 조회 및 수정, 회원 탈퇴 API")
+public interface UserApi {
+
+	@Operation(
+		summary = "사용자 정보 조회",
+		description = "사용자 정보를 조회합니다."
+	)
+	@ApiErrorCode({
+		"NOT_FOUND_USER",
+	})
+	ApiResponse<UserProfileResponse> getMe();
+}

--- a/backend/src/main/java/com/back/api/user/controller/UserController.java
+++ b/backend/src/main/java/com/back/api/user/controller/UserController.java
@@ -1,9 +1,31 @@
 package com.back.api.user.controller;
 
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.back.api.user.dto.response.UserProfileResponse;
+import com.back.api.user.service.UserService;
+import com.back.global.http.HttpRequestContext;
+import com.back.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequestMapping("/api/v1/users")
-public class UserController {
+@RequiredArgsConstructor
+@Validated
+public class UserController implements UserApi {
+
+	private final UserService userService;
+	private final HttpRequestContext httpRequestContext;
+
+	@Override
+	@GetMapping("/profile")
+	public ApiResponse<UserProfileResponse> getMe() {
+		long userId = httpRequestContext.getUser().getId();
+		UserProfileResponse response = userService.getUser(userId);
+		return ApiResponse.ok(String.format("%s 사용자 조회 성공", userId), response);
+	}
 }

--- a/backend/src/main/java/com/back/api/user/dto/response/UserProfileResponse.java
+++ b/backend/src/main/java/com/back/api/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,44 @@
+package com.back.api.user.dto.response;
+
+import com.back.domain.user.entity.UserRole;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 상세 정보 응답 DTO")
+public record UserProfileResponse(
+	@Schema(
+		description = "사용자 아이디 정보",
+		example = "1"
+	)
+	Long userId,
+	@Schema(
+		description = "사용자 이메일",
+		example = "user@example.com",
+		maxLength = 100
+	)
+	String email,
+
+	@Schema(
+		description = "사용자 닉네임",
+		maxLength = 20
+	)
+	String nickname,
+
+	@Schema(
+		description = "사용자 권한 범위"
+	)
+	UserRole role,
+
+	@Schema(
+		description = "사용자 생년월일",
+		example = "yyyy-MM-dd"
+	)
+	String birthDate,
+
+	@Schema(
+		description = "사용자 서비스 가입일",
+		example = "yyyy-MM-dd"
+	)
+	String signupDate
+) {
+}

--- a/backend/src/main/java/com/back/api/user/service/UserProfileResponseMapper.java
+++ b/backend/src/main/java/com/back/api/user/service/UserProfileResponseMapper.java
@@ -1,0 +1,31 @@
+package com.back.api.user.service;
+
+import java.time.format.DateTimeFormatter;
+
+import com.back.api.user.dto.response.UserProfileResponse;
+import com.back.domain.user.entity.User;
+
+public class UserProfileResponseMapper {
+
+	private static final DateTimeFormatter DATE_FORMATTER
+		= DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+	public static UserProfileResponse from(User user) {
+		String birthDateStr = user.getBirthDate() != null
+			? user.getBirthDate().format(DATE_FORMATTER)
+			: null;
+
+		String signupDateStr = user.getCreateAt() != null
+			? user.getCreateAt().toLocalDate().format(DATE_FORMATTER)
+			: null;
+
+		return new UserProfileResponse(
+			user.getId(),
+			user.getEmail(),
+			user.getNickname(),
+			user.getRole(),
+			birthDateStr,
+			signupDateStr
+		);
+	}
+}

--- a/backend/src/main/java/com/back/api/user/service/UserService.java
+++ b/backend/src/main/java/com/back/api/user/service/UserService.java
@@ -2,6 +2,24 @@ package com.back.api.user.service;
 
 import org.springframework.stereotype.Service;
 
+import com.back.api.user.dto.response.UserProfileResponse;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.error.code.UserErrorCode;
+import com.back.global.error.exception.ErrorException;
+
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class UserService {
+
+	private final UserRepository userRepository;
+
+	public UserProfileResponse getUser(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new ErrorException(UserErrorCode.NOT_FOUND));
+
+		return UserProfileResponseMapper.from(user);
+	}
 }

--- a/backend/src/main/java/com/back/global/error/code/UserErrorCode.java
+++ b/backend/src/main/java/com/back/global/error/code/UserErrorCode.java
@@ -1,0 +1,15 @@
+package com.back.global.error.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+	NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/backend/src/test/java/com/back/api/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/back/api/user/controller/UserControllerTest.java
@@ -1,0 +1,124 @@
+package com.back.api.user.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserRole;
+import com.back.global.error.code.AuthErrorCode;
+import com.back.global.security.SecurityUser;
+import com.back.support.data.TestUser;
+import com.back.support.helper.UserHelper;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+public class UserControllerTest {
+
+	@Autowired
+	private MockMvc mvc;
+
+	@Autowired
+	private UserHelper userHelper;
+	private User user;
+	SecurityUser securityUser;
+	UsernamePasswordAuthenticationToken authentication;
+
+	@BeforeEach
+	void setUp() {
+		TestUser testUser = userHelper.createUser(UserRole.NORMAL);
+		user = testUser.user();
+	}
+
+	@Nested
+	@DisplayName("GET `/api/v1/users/profile")
+	class GetUserTest {
+
+		private final String getUserApi = "/api/v1/users/profile";
+
+		@Test
+		@DisplayName("Success get user profile info")
+		void get_user_profile_success() throws Exception {
+			var authorities = AuthorityUtils.createAuthorityList("ROLE");
+			securityUser = new SecurityUser(
+				user.getId(),
+				user.getPassword(),
+				user.getNickname(),
+				UserRole.NORMAL, authorities
+			);
+			authentication =
+				new UsernamePasswordAuthenticationToken(securityUser, null, securityUser.getAuthorities());
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+
+			long userId = user.getId();
+
+			ResultActions actions = mvc
+				.perform(
+					get(getUserApi, userId)
+						.contentType(MediaType.APPLICATION_JSON)
+				).andDo(print());
+
+			actions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.status").value(HttpStatus.OK.name()))
+				.andExpect(jsonPath("$.message").value(String.format("%s 사용자 조회 성공", userId)));
+		}
+
+		@Test
+		@DisplayName("Failed by not allowed user")
+		void failed_by_not_allowed_user() throws Exception {
+			long userId = user.getId();
+
+			ResultActions actions = mvc
+				.perform(
+					get(getUserApi, userId)
+						.contentType(MediaType.APPLICATION_JSON)
+				).andDo(print());
+
+			AuthErrorCode error = AuthErrorCode.UNAUTHORIZED;
+
+			actions
+				.andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.name()))
+				.andExpect(jsonPath("$.message").value(error.getMessage()));
+		}
+
+		@Test
+		@DisplayName("Failed by wrong user id")
+		void failed_by_wrong_user_id() throws Exception {
+			long userId = user.getId();
+
+			ResultActions actions = mvc
+				.perform(
+					get(getUserApi, userId)
+						.contentType(MediaType.APPLICATION_JSON)
+				).andDo(print());
+
+			AuthErrorCode error = AuthErrorCode.UNAUTHORIZED;
+
+			actions
+				.andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.name()))
+				.andExpect(jsonPath("$.message").value(error.getMessage()));
+		}
+	}
+}

--- a/backend/src/test/rest/user.http
+++ b/backend/src/test/rest/user.http
@@ -1,0 +1,4 @@
+### 사용자 프로필 조회
+GET {{BASE_URL}}/api/v1/users/profile
+Authorization: Bearer {{ACCESS_TOKEN}}
+Content-Type: application/json


### PR DESCRIPTION
## 📌 개요
- 사용자 프로필 조회 기능 추가

---

## ✨ 작업 내용
- `/api/v1/users/profile` 엔드포인트 추가
- `UserController` 내부에 `getMe()` 메서드 추가: HttpRequestContext로부터 사용자 정보를 가져오도록 설정
- `UserService` 내부에 `getMe()` 메서드 추가
- 테스트 케이스 추가
- user.http 추가

---

## 🔗 관련 이슈
- close #55   

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
