### PR TITLE
[feat] 비밀번호 인증 기능 추가

### DIFF
--- a/backend/src/main/java/com/back/api/auth/controller/AuthApi.java
+++ b/backend/src/main/java/com/back/api/auth/controller/AuthApi.java
@@ -4,6 +4,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import com.back.api.auth.dto.request.LoginRequest;
 import com.back.api.auth.dto.request.SignupRequest;
+import com.back.api.auth.dto.request.VerifyPasswordRequest;
 import com.back.api.auth.dto.response.AuthResponse;
 import com.back.global.config.swagger.ApiErrorCode;
 import com.back.global.response.ApiResponse;
@@ -35,4 +36,11 @@ public interface AuthApi {
 		"UNAUTHORIZED"
 	})
 	ApiResponse<Void> logout();
+
+	@Operation(summary = "비밀번호 인증", description = "프로필 정보 수정 시 비밀번호 인증,"
+		+ " API 호출 성공하면 비밀번호 인증 성공입니다.")
+	@ApiErrorCode({
+		"PASSWORD_MISMATCH"
+	})
+	ApiResponse<Void> verifyPassword(@Valid @RequestBody VerifyPasswordRequest request);
 }

--- a/backend/src/main/java/com/back/api/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/back/api/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.back.api.auth.dto.request.LoginRequest;
 import com.back.api.auth.dto.request.SignupRequest;
+import com.back.api.auth.dto.request.VerifyPasswordRequest;
 import com.back.api.auth.dto.response.AuthResponse;
 import com.back.api.auth.service.AuthService;
 import com.back.global.response.ApiResponse;
@@ -46,5 +47,12 @@ public class AuthController implements AuthApi {
 	public ApiResponse<Void> logout() {
 		authService.logout();
 		return ApiResponse.noContent("로그아웃 되었습니다.");
+	}
+
+	@Override
+	@PostMapping("/verify-password")
+	public ApiResponse<Void> verifyPassword(@Valid @RequestBody VerifyPasswordRequest request) {
+		authService.verifyPassword(request.password());
+		return ApiResponse.noContent("비밀번호 인증 완료");
 	}
 }

--- a/backend/src/main/java/com/back/api/auth/dto/request/VerifyPasswordRequest.java
+++ b/backend/src/main/java/com/back/api/auth/dto/request/VerifyPasswordRequest.java
@@ -1,0 +1,13 @@
+package com.back.api.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "비밀번호 인증 요청 DTO")
+public record VerifyPasswordRequest(
+	@NotBlank(message = "비밀번호를 입력해주세요.")
+	@Size(min = 8, max = 30, message = "비밀번호는 8~30 글자여야 합니다.")
+	String password
+) {
+}

--- a/backend/src/main/java/com/back/api/auth/service/AuthService.java
+++ b/backend/src/main/java/com/back/api/auth/service/AuthService.java
@@ -99,6 +99,15 @@ public class AuthService {
 		requestContext.deleteCookie("refreshToken");
 	}
 
+	@Transactional
+	public void verifyPassword(String rawPassword) {
+		User user = requestContext.getUser();
+
+		if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
+			throw new ErrorException(AuthErrorCode.PASSWORD_MISMATCH);
+		}
+	}
+
 	private AuthResponse buildAuthResponse(User user, JwtDto tokens) {
 		TokenResponse tokenResponse = new TokenResponse(
 			tokens.tokenType(),

--- a/backend/src/main/java/com/back/global/error/code/AuthErrorCode.java
+++ b/backend/src/main/java/com/back/global/error/code/AuthErrorCode.java
@@ -18,7 +18,9 @@ public enum AuthErrorCode implements ErrorCode {
 	REFRESH_TOKEN_REQUIRED(HttpStatus.BAD_REQUEST, "리프레시 토큰이 없습니다."),
 	REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레시 토큰을 찾을 수 없습니다."),
 
-	LOGIN_FAILED(HttpStatus.BAD_REQUEST, "이메일과 비밀번호가 올바른지 확인해주세요.");
+	LOGIN_FAILED(HttpStatus.BAD_REQUEST, "이메일과 비밀번호가 올바른지 확인해주세요."),
+
+	PASSWORD_MISMATCH(HttpStatus.NOT_FOUND, "비밀번호가 일치하지 않습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/backend/src/test/rest/auth.http
+++ b/backend/src/test/rest/auth.http
@@ -51,6 +51,15 @@ Content-Type: application/json
     }
 %}
 
+### 비밀번호 검증
+POST {{BASE_URL}}/api/v1/auth/verify-password
+Cookie: {{COOKIE}}
+Content-Type: application/json
+
+{
+  "password": "qwer1234"
+}
+
 ### 로그아웃
 POST {{BASE_URL}}/api/v1/auth/logout
 Cookie: {{COOKIE}}


### PR DESCRIPTION
## 📌 개요
- 회원정보 수정 전 비밀번호 인증 기능 추가

---

## ✨ 작업 내용
- `POST /api/v1/auth/verify-password` 엔드포인트 추가
- AuthController > verifyPassword() 추가
- AuthService > verifyPassword() 추가
  - 입력값으로 들어온 비밀번호와 DB에 저장된 사용자의 비밀번호를 비교
- 테스트 케이스 추가
- auth.http > 비밀번호 인증 API 추가

---

## 🔗 관련 이슈
- close #68 

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
