### PR TITLE
[feat] 알림 기능 구현

### DIFF
--- a/backend/src/main/java/com/back/api/notification/controller/NotificationApi.java
+++ b/backend/src/main/java/com/back/api/notification/controller/NotificationApi.java
@@ -1,0 +1,56 @@
+package com.back.api.notification.controller;
+
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.back.api.notification.dto.NotificationResponseDto;
+import com.back.api.notification.dto.UnreadCountResponseDto;
+import com.back.global.config.swagger.ApiErrorCode;
+import com.back.global.response.ApiResponse;
+import com.back.global.security.SecurityUser;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Notification API", description = "알림 API")
+public interface NotificationApi {
+	@Operation(summary = "알림 조회", description = "웹소켓이 연결되기 전 발생한 알림들을 조회할 수 있습니다(초기 데이터 로딩). 웹소켓이 연결되면 새로운 알림은 웹소켓으로 전달됩니다 ")
+	@ApiErrorCode({
+		"NOTIFICATION_NOT_FOUND",
+		"NOTIFICATION_ACCESS_DENIED"
+	})
+	ApiResponse<List<NotificationResponseDto>> getNotifications(
+		@AuthenticationPrincipal SecurityUser securityUser
+	);
+
+	@Operation(summary = "읽지 않은 알림 개수 조회", description = "웹소켓이 연결된 직후 초기 데이터 로딩을 위해 이용됩니다")
+	@ApiErrorCode({
+		"NOTIFICATION_ACCESS_DENIED"
+	})
+	ApiResponse<UnreadCountResponseDto> getUnreadCount(
+		@AuthenticationPrincipal SecurityUser securityUser
+	);
+
+	@Operation(summary = "단일 알림 읽음 처리")
+	@ApiErrorCode({
+		"NOTIFICATION_ACCESS_DENIED",
+		"INVALID_NOTIFICATION_ID",
+		"NOTIFICATION_PROCESS_FAILED"
+	})
+	ApiResponse<Void> markAsRead(
+		@AuthenticationPrincipal SecurityUser securityUser,
+		@PathVariable Long notificationId
+	);
+
+	@Operation(summary = "모든 알림 읽음 처리")
+	@ApiErrorCode({
+		"NOTIFICATION_ACCESS_DENIED",
+		"INVALID_NOTIFICATION_ID",
+		"NOTIFICATION_PROCESS_FAILED"
+	})
+	ApiResponse<Void> markAllAsRead(
+		@AuthenticationPrincipal SecurityUser securityUser
+	);
+}

--- a/backend/src/main/java/com/back/api/notification/controller/NotificationController.java
+++ b/backend/src/main/java/com/back/api/notification/controller/NotificationController.java
@@ -1,0 +1,77 @@
+package com.back.api.notification.controller;
+
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.back.api.notification.dto.NotificationResponseDto;
+import com.back.api.notification.dto.UnreadCountResponseDto;
+import com.back.api.notification.service.NotificationService;
+import com.back.global.response.ApiResponse;
+import com.back.global.security.SecurityUser;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController implements NotificationApi {
+
+	private final NotificationService notificationService;
+
+	@Override
+	@GetMapping
+	public ApiResponse<List<NotificationResponseDto>> getNotifications(
+		@AuthenticationPrincipal SecurityUser securityUser
+	) {
+		Long userId = securityUser.getId();
+
+		List<NotificationResponseDto> notifications =
+			notificationService.getNotifications(userId);
+
+		return ApiResponse.ok(notifications);
+	}
+
+	/**
+	 * 읽지 않은 알림 개수 조회
+	 */
+	@Override
+	@GetMapping("/unread-count")
+	public ApiResponse<UnreadCountResponseDto> getUnreadCount(
+		@AuthenticationPrincipal SecurityUser securityUser
+	) {
+		long count = notificationService.getUnreadCount(securityUser.getId());
+		return ApiResponse.ok(new UnreadCountResponseDto(count));
+	}
+
+	/**
+	 * 개별 알림 읽음 처리
+	 */
+	@Override
+	@PatchMapping("/{notificationId}/read")
+	public ApiResponse<Void> markAsRead(
+		@AuthenticationPrincipal SecurityUser securityUser,
+		@PathVariable Long notificationId
+	) {
+		notificationService.markAsRead(notificationId, securityUser.getId());
+
+		return ApiResponse.noContent("개별 알림을 읽음 처리 하였습니다.");
+	}
+
+	/**
+	 * 전체 알림 읽음 처리
+	 */
+	@Override
+	@PatchMapping("/read-all")
+	public ApiResponse<Void> markAllAsRead(
+		@AuthenticationPrincipal SecurityUser securityUser
+	) {
+		notificationService.markAllAsRead(securityUser.getId());
+		return ApiResponse.noContent("모든 알림을 읽음 처리 하였습니다.");
+	}
+}

--- a/backend/src/main/java/com/back/api/notification/dto/NotificationResponseDto.java
+++ b/backend/src/main/java/com/back/api/notification/dto/NotificationResponseDto.java
@@ -1,0 +1,32 @@
+package com.back.api.notification.dto;
+
+import java.time.LocalDateTime;
+
+import com.back.domain.notification.entity.Notification;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "알림 조회 응답용 DTO")
+public record NotificationResponseDto(
+	Long id,
+	String type,          // enum name
+	String typeDetail,
+	String title,
+	String message,
+	boolean isRead,
+	LocalDateTime createdAt,
+	LocalDateTime readAt
+) {
+	public static NotificationResponseDto from(Notification notification) {
+		return new NotificationResponseDto(
+			notification.getId(),
+			notification.getType().name(),
+			notification.getTypeDetail().name(),
+			notification.getTitle(),
+			notification.getMessage(),
+			notification.isRead(),
+			notification.getCreateAt(),
+			notification.getReadAt()
+		);
+	}
+}

--- a/backend/src/main/java/com/back/api/notification/dto/UnreadCountResponseDto.java
+++ b/backend/src/main/java/com/back/api/notification/dto/UnreadCountResponseDto.java
@@ -1,0 +1,8 @@
+package com.back.api.notification.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "읽지 않은 알림 개수 조회 응답용 DTO")
+public record UnreadCountResponseDto(
+	long unreadCount
+) { }

--- a/backend/src/main/java/com/back/api/notification/listener/NotificationEventListener.java
+++ b/backend/src/main/java/com/back/api/notification/listener/NotificationEventListener.java
@@ -1,0 +1,98 @@
+package com.back.api.notification.listener;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.back.api.notification.dto.NotificationResponseDto;
+import com.back.domain.notification.entity.Notification;
+import com.back.domain.notification.repository.NotificationRepository;
+import com.back.domain.notification.systemMessage.NotificationMessage;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.websocket.session.WebSocketSessionManager;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationEventListener {
+	private final NotificationRepository notificationRepository;
+	private final UserRepository userRepository;
+	private final SimpMessagingTemplate messagingTemplate;
+	private final WebSocketSessionManager sessionManager;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleNotificationMessage(NotificationMessage message) {
+		try {
+			Notification notification = Notification.builder()
+				.user(
+					userRepository.findById(message.getUserId())
+					.orElseThrow(() -> new NoSuchElementException("ID " + message.getUserId() + "에 해당하는 사용자가 존재하지 않습니다."))
+				)
+				.type(message.getNotificationType())
+				.typeDetail(message.getTypeDetail())
+				.fromWhere(message.getFromWhere())
+				.whereId(message.getWhereId())
+				.title(message.getTitle())
+				.message(message.getMessage())
+				.isRead(false)
+				.build();
+
+			notificationRepository.save(notification);
+			log.info("알림 생성 완료 - userId: {}, type: {}, from: {}",
+				message.getUserId(),
+				message.getNotificationType(),
+				message.getFromWhere());
+
+			// 웹소켓으로 실시간 알림 전송
+			sendNotificationViaWebSocket(message.getUserId(), notification);
+
+		} catch (Exception e) {
+			log.error("알림 생성 실패 - userId: {}, type: {}",
+				message.getUserId(),
+				message.getNotificationType(),
+				e);
+			// 알림 생성 실패가 원본 트랜잭션에 영향 주지 않음
+		}
+	}
+
+	/**
+	 * 웹소켓으로 실시간 알림 전송
+	 *
+	 * @param userId 대상 사용자 ID
+	 * @param notification 전송할 알림 엔티티
+	 */
+	private void sendNotificationViaWebSocket(Long userId, Notification notification) {
+		// 사용자 온라인 여부 확인
+		if (!sessionManager.isUserOnline(userId)) {
+			log.debug("사용자 오프라인 - 웹소켓 전송 생략 - userId: {}", userId);
+			return;
+		}
+
+		try {
+			// DTO 변환
+			NotificationResponseDto dto = NotificationResponseDto.from(notification);
+
+			// 웹소켓 전송
+			messagingTemplate.convertAndSendToUser(
+				userId.toString(),
+				"/notifications",
+				dto
+			);
+
+			log.info("웹소켓 전송 성공 - userId: {}, notificationId: {}", userId, notification.getId());
+
+		} catch (Exception e) {
+			log.warn("웹소켓 전송 실패 - userId: {}, notificationId: {}, error: {}",
+				userId, notification.getId(), e.getMessage());
+			// 전송 실패해도 DB에는 저장되어 있으므로 예외를 던지지 않음
+		}
+	}
+}

--- a/backend/src/main/java/com/back/api/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/back/api/notification/service/NotificationService.java
@@ -1,0 +1,49 @@
+package com.back.api.notification.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.api.notification.dto.NotificationResponseDto;
+import com.back.domain.notification.entity.Notification;
+import com.back.domain.notification.repository.NotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+	private final NotificationRepository notificationRepository;
+
+	public List<NotificationResponseDto> getNotifications(Long userId) {
+		List<Notification> notifications = notificationRepository
+			.findByUserIdOrderByCreateAtDesc(userId);
+
+		return notifications.stream()
+			.map(NotificationResponseDto::from)
+			.toList();
+	}
+
+	public long getUnreadCount(Long userId) {
+		return notificationRepository.countByUserIdAndIsReadFalse(userId);
+	}
+
+	@Transactional
+	public void markAsRead(Long notificationId, Long userId) {
+		Notification notification = notificationRepository
+			.findByIdAndUserId(notificationId, userId)
+			.orElseThrow(() -> new IllegalArgumentException("알림을 찾을 수 없습니다"));
+
+		notification.markAsRead();
+	}
+
+	@Transactional
+	public void markAllAsRead(Long userId) {
+		List<Notification> notifications = notificationRepository
+			.findByUserIdAndIsReadFalse(userId);
+
+		notifications.forEach(Notification::markAsRead);
+	}
+}

--- a/backend/src/main/java/com/back/domain/notification/entity/Notification.java
+++ b/backend/src/main/java/com/back/domain/notification/entity/Notification.java
@@ -1,0 +1,76 @@
+package com.back.domain.notification.entity;
+
+import java.time.LocalDateTime;
+
+import com.back.domain.notification.enums.DomainName;
+import com.back.domain.notification.enums.NotificationTypeDetails;
+import com.back.domain.notification.enums.NotificationTypes;
+import com.back.domain.user.entity.User;
+import com.back.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+//TODO: User 엔티티쪽에 Cascade 설정 해줘야 함
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Table(name = "notifications")
+public class Notification extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private NotificationTypes type;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private NotificationTypeDetails typeDetail;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false)
+	private String message;
+
+	@Column(nullable = false)
+	private boolean isRead = false;
+
+	@Column(nullable = true)
+	private LocalDateTime readAt;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private DomainName fromWhere;
+
+	@Column(nullable = true)
+	private Long whereId;
+
+	//연관 필드
+	@ManyToOne(fetch = FetchType.LAZY) // -> 리팩토링 고민요소
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	public void markAsRead() {
+		this.isRead = true;
+		this.readAt = LocalDateTime.now();
+	}
+}

--- a/backend/src/main/java/com/back/domain/notification/enums/DomainName.java
+++ b/backend/src/main/java/com/back/domain/notification/enums/DomainName.java
@@ -1,0 +1,12 @@
+package com.back.domain.notification.enums;
+
+public enum DomainName {
+	//v1 기준 3가지 사용
+	//EVENT,
+	ORDERS,
+	//PAYMENT,
+	PRE_REGISTER,
+	QUEUE_ENTRIES,
+	//TICKETS,
+	//USERS
+}

--- a/backend/src/main/java/com/back/domain/notification/enums/NotificationTypeDetails.java
+++ b/backend/src/main/java/com/back/domain/notification/enums/NotificationTypeDetails.java
@@ -1,0 +1,18 @@
+package com.back.domain.notification.enums;
+
+// 세부 타입
+public enum NotificationTypeDetails {
+	// QueueEntries
+	TICKETING_POSSIBLE,          // 대기열 순서 완료
+
+	// PAYMENT
+	PAYMENT_SUCCESS,
+	PAYMENT_FAILED,
+
+	// PRE_REGISTER
+	PRE_REGISTER_DONE,
+
+	// TICKET
+	TICKET_GET
+}
+

--- a/backend/src/main/java/com/back/domain/notification/enums/NotificationTypes.java
+++ b/backend/src/main/java/com/back/domain/notification/enums/NotificationTypes.java
@@ -1,0 +1,10 @@
+package com.back.domain.notification.enums;
+
+// 큰 분류 (알림 / 결제 / 사전등록)
+public enum NotificationTypes {
+	QUEUE_ENTRIES,		// 대기열 알림
+	PAYMENT,            // 결제 관련
+	PRE_REGISTER,        // 사전 등록 관련
+	TICKET
+}
+

--- a/backend/src/main/java/com/back/domain/notification/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/back/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,19 @@
+package com.back.domain.notification.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.back.domain.notification.entity.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+	List<Notification> findByUserIdOrderByCreateAtDesc(Long userId);
+
+	long countByUserIdAndIsReadFalse(Long userId);
+
+	Optional<Notification> findByIdAndUserId(Long id, Long userId);
+
+	List<Notification> findByUserIdAndIsReadFalse(Long userId);
+}

--- a/backend/src/main/java/com/back/domain/notification/systemMessage/NotificationMessage.java
+++ b/backend/src/main/java/com/back/domain/notification/systemMessage/NotificationMessage.java
@@ -1,0 +1,30 @@
+package com.back.domain.notification.systemMessage;
+
+import com.back.domain.notification.enums.DomainName;
+import com.back.domain.notification.enums.NotificationTypeDetails;
+import com.back.domain.notification.enums.NotificationTypes;
+
+import lombok.Getter;
+
+@Getter
+public abstract class NotificationMessage {
+
+	private final Long userId;
+	private final DomainName fromWhere;
+	private final Long whereId;
+
+	protected NotificationMessage(Long userId, DomainName fromWhere, Long whereId) {
+		this.userId = userId;
+		this.fromWhere = fromWhere;
+		this.whereId = whereId;
+	}
+
+	// 각 구체 클래스에서 구현할 것
+	public abstract NotificationTypes getNotificationType();
+
+	public abstract NotificationTypeDetails getTypeDetail();
+
+	public abstract String getTitle();
+
+	public abstract String getMessage();
+}

--- a/backend/src/main/java/com/back/domain/notification/systemMessage/OrderFailedMessage.java
+++ b/backend/src/main/java/com/back/domain/notification/systemMessage/OrderFailedMessage.java
@@ -1,0 +1,34 @@
+package com.back.domain.notification.systemMessage;
+
+import com.back.domain.notification.enums.DomainName;
+import com.back.domain.notification.enums.NotificationTypeDetails;
+import com.back.domain.notification.enums.NotificationTypes;
+
+public class OrderFailedMessage extends NotificationMessage {
+	private final Long amount;
+	private final String eventName;
+	public OrderFailedMessage(Long userId, Long amount, Long whereId, String eventName) {
+		super(userId, DomainName.ORDERS, whereId);
+		this.amount = amount;
+		this.eventName = eventName;
+	}
+	@Override
+	public NotificationTypes getNotificationType() {
+		return NotificationTypes.PAYMENT;  // enum 값
+	}
+
+	@Override
+	public NotificationTypeDetails getTypeDetail() {
+		return NotificationTypeDetails.PAYMENT_FAILED;
+	}
+
+	@Override
+	public String getTitle() {
+		return "주문 및 결제 실패";
+	}
+
+	@Override
+	public String getMessage() {
+		return String.format("[%s]\n결제금액: %d원\n결제에 실패하였습니다", this.eventName, this.amount);
+	}
+}

--- a/backend/src/main/java/com/back/domain/notification/systemMessage/OrdersSuccessMessage.java
+++ b/backend/src/main/java/com/back/domain/notification/systemMessage/OrdersSuccessMessage.java
@@ -1,0 +1,38 @@
+package com.back.domain.notification.systemMessage;
+
+import static com.back.domain.notification.enums.DomainName.*;
+import static com.back.domain.notification.enums.NotificationTypeDetails.*;
+
+import com.back.domain.notification.enums.NotificationTypeDetails;
+import com.back.domain.notification.enums.NotificationTypes;
+
+public class OrdersSuccessMessage extends NotificationMessage {
+	private final Long amount;
+	private final String eventName;
+
+	public OrdersSuccessMessage(Long userId, Long orderId, Long amount, String eventName) {
+		super(userId, ORDERS, orderId);
+		this.amount = amount;
+		this.eventName = eventName;
+	}
+
+	@Override
+	public NotificationTypes getNotificationType() {
+		return NotificationTypes.PAYMENT;  // enum 값
+	}
+
+	@Override
+	public NotificationTypeDetails getTypeDetail() {
+		return PAYMENT_SUCCESS;
+	}
+
+	@Override
+	public String getTitle() {
+		return "주문 및 결제 완료";
+	}
+
+	@Override
+	public String getMessage() {
+		return String.format("[%s] 티켓 1매가 결제되었습니다\n결제금액: %d원", this.eventName, this.amount);
+	}
+}

--- a/backend/src/main/java/com/back/domain/notification/systemMessage/PreRegisterDoneMessage.java
+++ b/backend/src/main/java/com/back/domain/notification/systemMessage/PreRegisterDoneMessage.java
@@ -1,0 +1,36 @@
+package com.back.domain.notification.systemMessage;
+
+import static java.lang.String.*;
+
+import com.back.domain.notification.enums.DomainName;
+import com.back.domain.notification.enums.NotificationTypeDetails;
+import com.back.domain.notification.enums.NotificationTypes;
+
+public class PreRegisterDoneMessage extends NotificationMessage {
+	private final String eventName;
+
+	public PreRegisterDoneMessage(Long userId, Long whereId, String eventName) {
+		super(userId, DomainName.PRE_REGISTER, whereId);
+		this.eventName = eventName;
+	}
+
+	@Override
+	public NotificationTypes getNotificationType() {
+		return NotificationTypes.PRE_REGISTER;
+	}
+
+	@Override
+	public NotificationTypeDetails getTypeDetail() {
+		return NotificationTypeDetails.PRE_REGISTER_DONE;
+	}
+
+	@Override
+	public String getTitle() {
+		return "사전등록 완료";
+	}
+
+	@Override
+	public String getMessage() {
+		return format("[%s]\n사전등록이 완료되었습니다.\n티켓팅 시작일에 알림을 보내드리겠습니다.", this.eventName);
+	}
+}

--- a/backend/src/main/java/com/back/domain/notification/systemMessage/QueueEntriesMessage.java
+++ b/backend/src/main/java/com/back/domain/notification/systemMessage/QueueEntriesMessage.java
@@ -1,0 +1,36 @@
+package com.back.domain.notification.systemMessage;
+
+import static java.lang.String.*;
+
+import com.back.domain.notification.enums.DomainName;
+import com.back.domain.notification.enums.NotificationTypeDetails;
+import com.back.domain.notification.enums.NotificationTypes;
+
+public class QueueEntriesMessage extends NotificationMessage {
+	private final String eventName;
+
+	public QueueEntriesMessage(Long userId, Long whereId, String eventName) {
+		super(userId, DomainName.QUEUE_ENTRIES, whereId);
+		this.eventName = eventName;
+	}
+
+	@Override
+	public NotificationTypes getNotificationType() {
+		return NotificationTypes.QUEUE_ENTRIES;
+	}
+
+	@Override
+	public NotificationTypeDetails getTypeDetail() {
+		return NotificationTypeDetails.TICKETING_POSSIBLE;
+	}
+
+	@Override
+	public String getTitle() {
+		return "티켓팅 시작";
+	}
+
+	@Override
+	public String getMessage() {
+		return format("[%s]\n입장 준비가 완료되었습니다.\n이제 티켓을 구매하실 수 있습니다.", this.eventName);
+	}
+}

--- a/backend/src/main/java/com/back/domain/notification/systemMessage/TicketGetMessage.java
+++ b/backend/src/main/java/com/back/domain/notification/systemMessage/TicketGetMessage.java
@@ -1,0 +1,34 @@
+package com.back.domain.notification.systemMessage;
+
+import com.back.domain.notification.enums.DomainName;
+import com.back.domain.notification.enums.NotificationTypeDetails;
+import com.back.domain.notification.enums.NotificationTypes;
+
+public class TicketGetMessage extends NotificationMessage {
+	private final String eventName;
+
+	public TicketGetMessage(Long userId, DomainName fromWhere, Long whereId, String eventName) {
+		super(userId, fromWhere, whereId);
+		this.eventName = eventName;
+	}
+
+	@Override
+	public NotificationTypes getNotificationType() {
+		return NotificationTypes.TICKET;
+	}
+
+	@Override
+	public NotificationTypeDetails getTypeDetail() {
+		return NotificationTypeDetails.TICKET_GET;
+	}
+
+	@Override
+	public String getTitle() {
+		return "티켓 수령 완료";
+	}
+
+	@Override
+	public String getMessage() {
+		return String.format("[%s]\n티켓 1매가 발급되었습니다", this.eventName);
+	}
+}

--- a/backend/src/main/java/com/back/global/error/code/NotificationErrorCode.java
+++ b/backend/src/main/java/com/back/global/error/code/NotificationErrorCode.java
@@ -1,0 +1,26 @@
+package com.back.global.error.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+
+	// 404 NOT_FOUND (자원을 찾을 수 없을 때)
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 알림을 찾을 수 없습니다."),
+
+	// 403 FORBIDDEN (인가되지 않은 접근 시도 - 다른 사용자 알림 접근)
+	NOTIFICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 알림에 접근할 권한이 없습니다."),
+
+	// 400 BAD_REQUEST (잘못된 요청 데이터)
+	INVALID_NOTIFICATION_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 알림 ID 형식입니다."),
+
+	// 500 INTERNAL_SERVER_ERROR (서버 내부 에러)
+	NOTIFICATION_PROCESS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "알림 처리 중 서버 내부 오류가 발생했습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/backend/src/main/java/com/back/global/init/NotificationDataInit.java
+++ b/backend/src/main/java/com/back/global/init/NotificationDataInit.java
@@ -1,0 +1,140 @@
+package com.back.global.init;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.back.domain.event.entity.Event;
+import com.back.domain.event.repository.EventRepository;
+import com.back.domain.notification.entity.Notification;
+import com.back.domain.notification.enums.DomainName;
+import com.back.domain.notification.repository.NotificationRepository;
+import com.back.domain.notification.systemMessage.NotificationMessage;
+import com.back.domain.notification.systemMessage.OrderFailedMessage;
+import com.back.domain.notification.systemMessage.OrdersSuccessMessage;
+import com.back.domain.notification.systemMessage.PreRegisterDoneMessage;
+import com.back.domain.notification.systemMessage.QueueEntriesMessage;
+import com.back.domain.notification.systemMessage.TicketGetMessage;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Profile("dev")
+@Order(5)
+public class NotificationDataInit implements ApplicationRunner {
+
+	private final NotificationRepository notificationRepository;
+	private final UserRepository userRepository;
+	private final EventRepository eventRepository;
+
+	@Override
+	public void run(ApplicationArguments args) {
+		if (notificationRepository.count() > 0) {
+			log.info("Notification 데이터가 이미 존재합니다. 초기화를 건너뜁니다.");
+			return;
+		}
+
+		log.info("Notification 초기 데이터를 생성합니다.");
+
+		// 유저 1번, 2번 조회
+		Optional<User> user1Opt = userRepository.findById(1L);
+		Optional<User> user2Opt = userRepository.findById(2L);
+
+		if (user1Opt.isEmpty() || user2Opt.isEmpty()) {
+			log.warn("User ID 1번 또는 2번이 없습니다. UserDataInit을 먼저 실행해주세요.");
+			return;
+		}
+
+		// 이벤트 1번 조회
+		Optional<Event> eventOpt = eventRepository.findById(1L);
+		if (eventOpt.isEmpty()) {
+			log.warn("Event ID 1번이 없습니다. EventDataInit을 먼저 실행해주세요.");
+			return;
+		}
+
+		User user1 = user1Opt.get();
+		User user2 = user2Opt.get();
+		Event event = eventOpt.get();
+		String eventName = event.getTitle();
+
+		List<Notification> notifications = new ArrayList<>();
+
+		// ===== 유저 1번 알림 (총 5개) =====
+		// 안읽은 알림 3개
+		notifications.add(createNotificationFromMessage(user1,
+			new OrdersSuccessMessage(user1.getId(), 1L, 99000L, eventName), false));
+
+		notifications.add(createNotificationFromMessage(user1,
+			new QueueEntriesMessage(user1.getId(), 101L, eventName), false));
+
+		notifications.add(createNotificationFromMessage(user1,
+			new PreRegisterDoneMessage(user1.getId(), 201L, eventName), false));
+
+		// 읽은 알림 2개
+		notifications.add(createNotificationFromMessage(user1,
+			new TicketGetMessage(user1.getId(), DomainName.ORDERS, 301L, eventName), true));
+
+		notifications.add(createNotificationFromMessage(user1,
+			new OrderFailedMessage(user1.getId(), 154000L, 51L, eventName), true));
+
+		// ===== 유저 2번 알림 (총 5개) =====
+		// 안읽은 알림 3개
+		notifications.add(createNotificationFromMessage(user2,
+			new PreRegisterDoneMessage(user2.getId(), 202L, eventName), false));
+
+		notifications.add(createNotificationFromMessage(user2,
+			new QueueEntriesMessage(user2.getId(), 102L, eventName), false));
+
+		notifications.add(createNotificationFromMessage(user2,
+			new OrdersSuccessMessage(user2.getId(), 2L, 154000L, eventName), false));
+
+		// 읽은 알림 2개
+		notifications.add(createNotificationFromMessage(user2,
+			new OrderFailedMessage(user2.getId(), 99000L, 52L, eventName), true));
+
+		notifications.add(createNotificationFromMessage(user2,
+			new TicketGetMessage(user2.getId(), DomainName.ORDERS, 302L, eventName), true));
+
+		notificationRepository.saveAll(notifications);
+
+		log.info("Notification 초기 데이터 {}개가 생성되었습니다. (유저1: 5개, 유저2: 5개)", notifications.size());
+	}
+
+	/**
+	 * NotificationMessage로부터 Notification 엔티티 생성
+	 *
+	 * @param user 대상 유저
+	 * @param message 알림 메시지
+	 * @param isRead 읽음 여부
+	 */
+	private Notification createNotificationFromMessage(User user, NotificationMessage message, boolean isRead) {
+		Notification notification = Notification.builder()
+			.user(user)
+			.type(message.getNotificationType())
+			.typeDetail(message.getTypeDetail())
+			.fromWhere(message.getFromWhere())
+			.whereId(message.getWhereId())
+			.title(message.getTitle())
+			.message(message.getMessage())
+			.isRead(false)
+			.build();
+
+		// 읽음 처리
+		if (isRead) {
+			notification.markAsRead();
+		}
+
+		return notification;
+	}
+}

--- a/backend/src/main/java/com/back/global/websocket/auth/UserPrincipal.java
+++ b/backend/src/main/java/com/back/global/websocket/auth/UserPrincipal.java
@@ -1,0 +1,26 @@
+package com.back.global.websocket.auth;
+
+import java.security.Principal;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * WebSocket Principal 구현체
+ * STOMP 세션에서 사용자를 식별하기 위한 클래스
+ */
+@Getter
+@RequiredArgsConstructor
+public class UserPrincipal implements Principal {
+
+	private final Long userId;
+
+	/**
+	 * Principal의 name은 String이어야 하므로 userId를 String으로 변환
+	 * convertAndSendToUser(name, ...) 호출 시 이 값과 매칭됨
+	 */
+	@Override
+	public String getName() {
+		return userId.toString();
+	}
+}

--- a/backend/src/main/java/com/back/global/websocket/auth/WebSocketAuthInterceptor.java
+++ b/backend/src/main/java/com/back/global/websocket/auth/WebSocketAuthInterceptor.java
@@ -1,0 +1,69 @@
+package com.back.global.websocket.auth;
+
+import java.util.Map;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+import com.back.global.security.JwtProvider;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * WebSocket 연결 시 STOMP 헤더에서 JWT를 검증하는 Interceptor
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketAuthInterceptor implements ChannelInterceptor {
+
+	private static final String BEARER_PREFIX = "Bearer ";
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+
+	private final JwtProvider jwtProvider;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+		if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+			// STOMP CONNECT 프레임일 때만 인증 처리
+			String authHeader = accessor.getFirstNativeHeader(AUTHORIZATION_HEADER);
+
+			if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+				log.warn("웹소켓 연결 거부 - Authorization 헤더 없음 또는 형식 오류");
+				throw new IllegalArgumentException("Authorization 헤더가 없거나 형식이 올바르지 않습니다");
+			}
+
+			String token = authHeader.substring(BEARER_PREFIX.length());
+
+			// JWT 만료 검증
+			if (jwtProvider.isExpired(token)) {
+				log.warn("웹소켓 연결 거부 - JWT 만료");
+				throw new IllegalArgumentException("만료된 토큰입니다");
+			}
+
+			// JWT 파싱 및 userId 추출
+			Map<String, Object> payload = jwtProvider.payloadOrNull(token);
+			if (payload == null) {
+				log.warn("웹소켓 연결 거부 - JWT 파싱 실패");
+				throw new IllegalArgumentException("유효하지 않은 토큰입니다");
+			}
+
+			Long userId = ((Number) payload.get("id")).longValue();
+
+			// Principal 설정 (convertAndSendToUser에서 사용)
+			accessor.setUser(new UserPrincipal(userId));
+
+			log.info("웹소켓 연결 성공 - userId: {}", userId);
+		}
+
+		return message;
+	}
+}

--- a/backend/src/main/java/com/back/global/websocket/session/WebSocketSessionManager.java
+++ b/backend/src/main/java/com/back/global/websocket/session/WebSocketSessionManager.java
@@ -1,0 +1,86 @@
+package com.back.global.websocket.session;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import com.back.global.websocket.auth.UserPrincipal;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * WebSocket 세션 관리 클래스
+ * 사용자 온라인 여부 체크 및 userId ↔ sessionId 매핑 관리
+ */
+@Slf4j
+@Component
+public class WebSocketSessionManager {
+
+	// userId → sessionId 매핑
+	// ConcurrentHashMap 사용으로 thread-safe 보장
+	private final ConcurrentHashMap<Long, String> userSessions = new ConcurrentHashMap<>();
+
+	/**
+	 * 웹소켓 연결 성공 시 호출
+	 */
+	@EventListener
+	public void handleWebSocketConnectListener(SessionConnectEvent event) {
+		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+
+		if (headerAccessor.getUser() instanceof UserPrincipal principal) {
+			Long userId = principal.getUserId();
+			String sessionId = headerAccessor.getSessionId();
+
+			userSessions.put(userId, sessionId);
+			log.info("웹소켓 세션 저장 - userId: {}, sessionId: {}", userId, sessionId);
+		}
+	}
+
+	/**
+	 * 웹소켓 연결 해제 시 호출
+	 */
+	@EventListener
+	public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+
+		if (headerAccessor.getUser() instanceof UserPrincipal principal) {
+			Long userId = principal.getUserId();
+
+			userSessions.remove(userId);
+			log.info("웹소켓 세션 제거 - userId: {}", userId);
+		}
+	}
+
+	/**
+	 * 사용자 온라인 여부 확인
+	 *
+	 * @param userId 확인할 사용자 ID
+	 * @return 온라인이면 true, 오프라인이면 false
+	 */
+	public boolean isUserOnline(Long userId) {
+		return userSessions.containsKey(userId);
+	}
+
+	/**
+	 * 특정 사용자의 세션 ID 조회
+	 *
+	 * @param userId 사용자 ID
+	 * @return 세션 ID (없으면 null)
+	 */
+	public String getSessionId(Long userId) {
+		return userSessions.get(userId);
+	}
+
+	/**
+	 * 현재 온라인 사용자 수
+	 *
+	 * @return 온라인 사용자 수
+	 */
+	public int getOnlineUserCount() {
+		return userSessions.size();
+	}
+}

--- a/backend/src/test/java/com/back/api/notification/listener/NotificationEventListenerTest.java
+++ b/backend/src/test/java/com/back/api/notification/listener/NotificationEventListenerTest.java
@@ -1,0 +1,539 @@
+package com.back.api.notification.listener;
+
+import static java.util.concurrent.TimeUnit.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.reset;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.back.api.notification.dto.NotificationResponseDto;
+import com.back.domain.event.entity.Event;
+import com.back.domain.event.entity.EventCategory;
+import com.back.domain.event.entity.EventStatus;
+import com.back.domain.event.repository.EventRepository;
+import com.back.domain.notification.entity.Notification;
+import com.back.domain.notification.enums.DomainName;
+import com.back.domain.notification.enums.NotificationTypeDetails;
+import com.back.domain.notification.enums.NotificationTypes;
+import com.back.domain.notification.repository.NotificationRepository;
+import com.back.domain.notification.systemMessage.OrderFailedMessage;
+import com.back.domain.notification.systemMessage.OrdersSuccessMessage;
+import com.back.domain.notification.systemMessage.PreRegisterDoneMessage;
+import com.back.domain.notification.systemMessage.QueueEntriesMessage;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserActiveStatus;
+import com.back.domain.user.entity.UserRole;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.websocket.session.WebSocketSessionManager;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("NotificationEventListener 통합 테스트")
+class NotificationEventListenerTest {
+
+	@Autowired
+	private ApplicationEventPublisher eventPublisher;
+
+	@Autowired
+	private NotificationRepository notificationRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private EventRepository eventRepository;
+
+	@Autowired
+	private TransactionHelper transactionHelper;
+
+	@MockBean
+	private SimpMessagingTemplate messagingTemplate;
+
+	@MockBean
+	private WebSocketSessionManager sessionManager;
+
+	private User testUser;
+	private Event testEvent;
+
+	@BeforeEach
+	void setUp() {
+		// 기존 데이터 정리 (테스트 격리를 위해)
+		notificationRepository.deleteAll();
+		eventRepository.deleteAll();
+		userRepository.deleteAll();
+
+		// 테스트 유저 생성
+		testUser = userRepository.save(User.builder()
+			.email("test@example.com")
+			.nickname("tester")
+			.password("encoded_password")
+			.fullName("Test User")
+			.role(UserRole.NORMAL)
+			.activeStatus(UserActiveStatus.ACTIVE)
+			.build());
+
+		// 테스트 이벤트 생성
+		testEvent = eventRepository.save(Event.builder()
+			.title("테스트 이벤트")
+			.category(EventCategory.CONCERT)
+			.place("테스트 장소")
+			.minPrice(50000)
+			.maxPrice(150000)
+			.preOpenAt(java.time.LocalDateTime.now().plusDays(1))
+			.preCloseAt(java.time.LocalDateTime.now().plusDays(3))
+			.ticketOpenAt(java.time.LocalDateTime.now().plusDays(5))
+			.ticketCloseAt(java.time.LocalDateTime.now().plusDays(7))
+			.maxTicketAmount(1000)
+			.status(EventStatus.READY)
+			.build());
+
+		// Mock 초기화
+		reset(messagingTemplate, sessionManager);
+	}
+
+	@Nested
+	@DisplayName("OrdersSuccessMessage 테스트")
+	class OrdersSuccessMessageTest {
+
+		@Test
+		@DisplayName("온라인 유저 - DB 저장 및 웹소켓 전송")
+		void publishOrdersSuccessMessage_UserOnline_SavesAndSendsWebSocket() {
+			// given
+			given(sessionManager.isUserOnline(testUser.getId())).willReturn(true);
+
+			// when: 이벤트 발행 (별도 트랜잭션으로 커밋되어야 AFTER_COMMIT 리스너 실행)
+			transactionHelper.executeInNewTransaction(() -> {
+				OrdersSuccessMessage message = new OrdersSuccessMessage(
+					testUser.getId(),
+					1L,
+					99000L,
+					testEvent.getTitle()
+				);
+				eventPublisher.publishEvent(message);
+			});
+
+			// then: 비동기 대기 후 검증
+			await().atMost(5, SECONDS).untilAsserted(() -> {
+				// DB 저장 확인
+				List<Notification> notifications = notificationRepository
+					.findByUserIdOrderByCreateAtDesc(testUser.getId());
+				assertThat(notifications).hasSize(1);
+
+				Notification saved = notifications.get(0);
+				assertThat(saved.getType()).isEqualTo(NotificationTypes.PAYMENT);
+				assertThat(saved.getTypeDetail()).isEqualTo(NotificationTypeDetails.PAYMENT_SUCCESS);
+				assertThat(saved.getFromWhere()).isEqualTo(DomainName.ORDERS);
+				assertThat(saved.getTitle()).isEqualTo("주문 및 결제 완료");
+				assertThat(saved.getMessage()).contains("테스트 이벤트", "99000원");
+				assertThat(saved.isRead()).isFalse();
+
+				// 웹소켓 전송 확인
+				verify(messagingTemplate).convertAndSendToUser(
+					eq(testUser.getId().toString()),
+					eq("/notifications"),
+					any(NotificationResponseDto.class)
+				);
+			});
+		}
+
+		@Test
+		@DisplayName("오프라인 유저 - DB 저장만, 웹소켓 미전송")
+		void publishOrdersSuccessMessage_UserOffline_SavesOnlyWithoutWebSocket() {
+			// given
+			given(sessionManager.isUserOnline(testUser.getId())).willReturn(false);
+
+			// when
+			transactionHelper.executeInNewTransaction(() -> {
+				OrdersSuccessMessage message = new OrdersSuccessMessage(
+					testUser.getId(),
+					1L,
+					99000L,
+					testEvent.getTitle()
+				);
+				eventPublisher.publishEvent(message);
+			});
+
+			// then
+			await().atMost(3, SECONDS).untilAsserted(() -> {
+				// DB 저장 확인
+				List<Notification> notifications = notificationRepository
+					.findByUserIdOrderByCreateAtDesc(testUser.getId());
+				assertThat(notifications).hasSize(1);
+
+				// 웹소켓 미전송 확인
+				verify(messagingTemplate, never()).convertAndSendToUser(
+					anyString(),
+					anyString(),
+					any()
+				);
+			});
+		}
+		@Test
+		@DisplayName("알림 타입 및 상세 정보 검증")
+		void publishOrdersSuccessMessage_VerifyNotificationTypeDetails() {
+			// given
+			given(sessionManager.isUserOnline(testUser.getId())).willReturn(true);
+
+			// when
+			transactionHelper.executeInNewTransaction(() -> {
+				OrdersSuccessMessage message = new OrdersSuccessMessage(
+					testUser.getId(),
+					1L,
+					99000L,
+					testEvent.getTitle()
+				);
+				eventPublisher.publishEvent(message);
+			});
+
+			// then
+			await().atMost(3, SECONDS).untilAsserted(() -> {
+				List<Notification> notifications = notificationRepository
+					.findByUserIdOrderByCreateAtDesc(testUser.getId());
+
+				Notification saved = notifications.get(0);
+				assertThat(saved.getType()).isEqualTo(NotificationTypes.PAYMENT);
+				assertThat(saved.getTypeDetail()).isEqualTo(NotificationTypeDetails.PAYMENT_SUCCESS);
+				assertThat(saved.getFromWhere()).isEqualTo(DomainName.ORDERS);
+				assertThat(saved.getWhereId()).isEqualTo(1L);
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("OrderFailedMessage 테스트")
+	class OrderFailedMessageTest {
+
+		@Test
+		@DisplayName("온라인 유저 - 실패 알림 생성 및 전송")
+		void publishOrderFailedMessage_UserOnline_SavesAndSendsWebSocket() {
+			// given
+			given(sessionManager.isUserOnline(testUser.getId())).willReturn(true);
+
+			// when
+			transactionHelper.executeInNewTransaction(() -> {
+				OrderFailedMessage message = new OrderFailedMessage(
+					testUser.getId(),
+					154000L,
+					51L,
+					testEvent.getTitle()
+				);
+				eventPublisher.publishEvent(message);
+			});
+
+			// then
+			await().atMost(3, SECONDS).untilAsserted(() -> {
+				List<Notification> notifications = notificationRepository
+					.findByUserIdOrderByCreateAtDesc(testUser.getId());
+				assertThat(notifications).hasSize(1);
+
+				Notification saved = notifications.get(0);
+				assertThat(saved.getTitle()).isEqualTo("주문 및 결제 실패");
+				assertThat(saved.getMessage()).contains("테스트 이벤트", "154000원", "실패");
+
+				verify(messagingTemplate).convertAndSendToUser(
+					eq(testUser.getId().toString()),
+					eq("/notifications"),
+					any(NotificationResponseDto.class)
+				);
+			});
+		}
+
+		@Test
+		@DisplayName("실패 알림 타입 검증")
+		void publishOrderFailedMessage_VerifyFailedType() {
+			// given
+			given(sessionManager.isUserOnline(testUser.getId())).willReturn(true);
+
+			// when
+			transactionHelper.executeInNewTransaction(() -> {
+				OrderFailedMessage message = new OrderFailedMessage(
+					testUser.getId(),
+					154000L,
+					51L,
+					testEvent.getTitle()
+				);
+				eventPublisher.publishEvent(message);
+			});
+
+			// then
+			await().atMost(3, SECONDS).untilAsserted(() -> {
+				List<Notification> notifications = notificationRepository
+					.findByUserIdOrderByCreateAtDesc(testUser.getId());
+
+				Notification saved = notifications.get(0);
+				assertThat(saved.getType()).isEqualTo(NotificationTypes.PAYMENT);
+				assertThat(saved.getTypeDetail()).isEqualTo(NotificationTypeDetails.PAYMENT_FAILED);
+				assertThat(saved.getFromWhere()).isEqualTo(DomainName.ORDERS);
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("PreRegisterDoneMessage 테스트")
+	class PreRegisterDoneMessageTest {
+
+		@Test
+		@DisplayName("사전등록 완료 알림 생성 및 전송")
+		void publishPreRegisterDoneMessage_UserOnline_SavesAndSendsWebSocket() {
+			// given
+			given(sessionManager.isUserOnline(testUser.getId())).willReturn(true);
+
+			// when
+			transactionHelper.executeInNewTransaction(() -> {
+				PreRegisterDoneMessage message = new PreRegisterDoneMessage(
+					testUser.getId(),
+					201L,
+					testEvent.getTitle()
+				);
+				eventPublisher.publishEvent(message);
+			});
+
+			// then
+			await().atMost(3, SECONDS).untilAsserted(() -> {
+				List<Notification> notifications = notificationRepository
+					.findByUserIdOrderByCreateAtDesc(testUser.getId());
+				assertThat(notifications).hasSize(1);
+
+				Notification saved = notifications.get(0);
+				assertThat(saved.getTitle()).isEqualTo("사전등록 완료");
+				assertThat(saved.getMessage()).contains("테스트 이벤트", "사전등록이 완료");
+
+				verify(messagingTemplate).convertAndSendToUser(
+					eq(testUser.getId().toString()),
+					eq("/notifications"),
+					any(NotificationResponseDto.class)
+				);
+			});
+		}
+
+		@Test
+		@DisplayName("사전등록 알림 타입 검증")
+		void publishPreRegisterDoneMessage_VerifyType() {
+			// given
+			given(sessionManager.isUserOnline(testUser.getId())).willReturn(true);
+
+			// when
+			transactionHelper.executeInNewTransaction(() -> {
+				PreRegisterDoneMessage message = new PreRegisterDoneMessage(
+					testUser.getId(),
+					201L,
+					testEvent.getTitle()
+				);
+				eventPublisher.publishEvent(message);
+			});
+
+			// then
+			await().atMost(3, SECONDS).untilAsserted(() -> {
+				List<Notification> notifications = notificationRepository
+					.findByUserIdOrderByCreateAtDesc(testUser.getId());
+
+				Notification saved = notifications.get(0);
+				assertThat(saved.getType()).isEqualTo(NotificationTypes.PRE_REGISTER);
+				assertThat(saved.getTypeDetail()).isEqualTo(NotificationTypeDetails.PRE_REGISTER_DONE);
+				assertThat(saved.getFromWhere()).isEqualTo(DomainName.PRE_REGISTER);
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("QueueEntriesMessage 테스트")
+	class QueueEntriesMessageTest {
+
+		@Test
+		@DisplayName("대기열 진입 알림 생성 및 전송")
+		void publishQueueEntriesMessage_UserOnline_SavesAndSendsWebSocket() {
+			// given
+			given(sessionManager.isUserOnline(testUser.getId())).willReturn(true);
+
+			// when
+			transactionHelper.executeInNewTransaction(() -> {
+				QueueEntriesMessage message = new QueueEntriesMessage(
+					testUser.getId(),
+					101L,
+					testEvent.getTitle()
+				);
+				eventPublisher.publishEvent(message);
+			});
+
+			// then
+			await().atMost(3, SECONDS).untilAsserted(() -> {
+				List<Notification> notifications = notificationRepository
+					.findByUserIdOrderByCreateAtDesc(testUser.getId());
+				assertThat(notifications).hasSize(1);
+
+				Notification saved = notifications.get(0);
+				assertThat(saved.getTitle()).isEqualTo("티켓팅 시작");
+				assertThat(saved.getMessage()).contains("테스트 이벤트", "입장 준비가 완료");
+
+				verify(messagingTemplate).convertAndSendToUser(
+					eq(testUser.getId().toString()),
+					eq("/notifications"),
+					any(NotificationResponseDto.class)
+				);
+			});
+		}
+
+		@Test
+		@DisplayName("대기열 알림 타입 검증")
+		void publishQueueEntriesMessage_VerifyType() {
+			// given
+			given(sessionManager.isUserOnline(testUser.getId())).willReturn(true);
+
+			// when
+			transactionHelper.executeInNewTransaction(() -> {
+				QueueEntriesMessage message = new QueueEntriesMessage(
+					testUser.getId(),
+					101L,
+					testEvent.getTitle()
+				);
+				eventPublisher.publishEvent(message);
+			});
+
+			// then
+			await().atMost(3, SECONDS).untilAsserted(() -> {
+				List<Notification> notifications = notificationRepository
+					.findByUserIdOrderByCreateAtDesc(testUser.getId());
+
+				Notification saved = notifications.get(0);
+				assertThat(saved.getType()).isEqualTo(NotificationTypes.QUEUE_ENTRIES);
+				assertThat(saved.getTypeDetail()).isEqualTo(NotificationTypeDetails.TICKETING_POSSIBLE);
+				assertThat(saved.getFromWhere()).isEqualTo(DomainName.QUEUE_ENTRIES);
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("에러 시나리오 테스트")
+	class ErrorScenarioTest {
+
+		@Test
+		@DisplayName("존재하지 않는 유저 ID - DB 저장 실패")
+		void publishMessage_NonExistentUser_DoesNotSaveNotification() {
+			// given
+			Long nonExistentUserId = 99999L;
+			given(sessionManager.isUserOnline(nonExistentUserId)).willReturn(true);
+
+			// when
+			transactionHelper.executeInNewTransaction(() -> {
+				OrdersSuccessMessage message = new OrdersSuccessMessage(
+					nonExistentUserId,
+					1L,
+					99000L,
+					testEvent.getTitle()
+				);
+				eventPublisher.publishEvent(message);
+			});
+
+			// then: 알림이 생성되지 않음
+			await().atMost(3, SECONDS).untilAsserted(() -> {
+				List<Notification> notifications = notificationRepository
+					.findByUserIdOrderByCreateAtDesc(nonExistentUserId);
+				assertThat(notifications).isEmpty();
+
+				// 웹소켓도 전송되지 않음
+				verify(messagingTemplate, never()).convertAndSendToUser(
+					anyString(),
+					anyString(),
+					any()
+				);
+			});
+		}
+
+		@Test
+		@DisplayName("웹소켓 전송 실패 - DB는 저장됨, 예외 전파 안 됨")
+		void publishMessage_WebSocketFails_StillSavesNotification() {
+			// given
+			given(sessionManager.isUserOnline(testUser.getId())).willReturn(true);
+			willThrow(new RuntimeException("웹소켓 전송 실패"))
+				.given(messagingTemplate).convertAndSendToUser(
+					anyString(),
+					anyString(),
+					any()
+				);
+
+			// when
+			transactionHelper.executeInNewTransaction(() -> {
+				OrdersSuccessMessage message = new OrdersSuccessMessage(
+					testUser.getId(),
+					1L,
+					99000L,
+					testEvent.getTitle()
+				);
+				eventPublisher.publishEvent(message);
+			});
+
+			// then: DB에는 저장됨 (웹소켓 실패가 DB 저장에 영향 없음)
+			await().atMost(3, SECONDS).untilAsserted(() -> {
+				List<Notification> notifications = notificationRepository
+					.findByUserIdOrderByCreateAtDesc(testUser.getId());
+				assertThat(notifications).hasSize(1);
+
+				// 웹소켓 전송 시도는 있었음
+				verify(messagingTemplate).convertAndSendToUser(
+					eq(testUser.getId().toString()),
+					eq("/notifications"),
+					any(NotificationResponseDto.class)
+				);
+			});
+		}
+
+		@Test
+		@DisplayName("여러 이벤트 동시 발행 - 모두 정상 처리")
+		void publishMultipleMessages_AllProcessedSuccessfully() {
+			// given
+			given(sessionManager.isUserOnline(testUser.getId())).willReturn(true);
+
+			// when: 4가지 메시지 타입 연속 발행
+			transactionHelper.executeInNewTransaction(() -> {
+				eventPublisher.publishEvent(new OrdersSuccessMessage(
+					testUser.getId(), 1L, 99000L, testEvent.getTitle()));
+				eventPublisher.publishEvent(new OrderFailedMessage(
+					testUser.getId(), 154000L, 51L, testEvent.getTitle()));
+				eventPublisher.publishEvent(new PreRegisterDoneMessage(
+					testUser.getId(), 201L, testEvent.getTitle()));
+				eventPublisher.publishEvent(new QueueEntriesMessage(
+					testUser.getId(), 101L, testEvent.getTitle()));
+			});
+
+			// then: 4개 모두 저장됨
+			await().atMost(5, SECONDS).untilAsserted(() -> {
+				List<Notification> notifications = notificationRepository
+					.findByUserIdOrderByCreateAtDesc(testUser.getId());
+				assertThat(notifications).hasSize(4);
+
+				// 각 타입별 확인
+				assertThat(notifications)
+					.extracting(Notification::getType)
+					.containsExactlyInAnyOrder(
+						NotificationTypes.PAYMENT,
+						NotificationTypes.PAYMENT,
+						NotificationTypes.PRE_REGISTER,
+						NotificationTypes.QUEUE_ENTRIES
+					);
+
+				// 웹소켓 4번 전송 확인
+				verify(messagingTemplate, times(4)).convertAndSendToUser(
+					eq(testUser.getId().toString()),
+					eq("/notifications"),
+					any(NotificationResponseDto.class)
+				);
+			});
+		}
+	}
+
+}

--- a/backend/src/test/java/com/back/api/notification/listener/TransactionHelper.java
+++ b/backend/src/test/java/com/back/api/notification/listener/TransactionHelper.java
@@ -1,0 +1,22 @@
+package com.back.api.notification.listener;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 테스트용 트랜잭션 헬퍼
+ * Self-Invocation 문제를 해결하기 위해 별도 컴포넌트로 분리
+ */
+@Component
+public class TransactionHelper {
+
+	/**
+	 * 별도 트랜잭션으로 이벤트 발행
+	 * @TransactionalEventListener(AFTER_COMMIT)가 동작하려면 트랜잭션이 커밋되어야 함
+	 */
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void executeInNewTransaction(Runnable action) {
+		action.run();
+	}
+}

--- a/backend/src/test/java/com/back/api/notification/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/back/api/notification/service/NotificationServiceTest.java
@@ -1,0 +1,389 @@
+package com.back.api.notification.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.back.api.notification.dto.NotificationResponseDto;
+import com.back.domain.notification.entity.Notification;
+import com.back.domain.notification.enums.DomainName;
+import com.back.domain.notification.enums.NotificationTypeDetails;
+import com.back.domain.notification.enums.NotificationTypes;
+import com.back.domain.notification.repository.NotificationRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserActiveStatus;
+import com.back.domain.user.entity.UserRole;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationService 단위 테스트")
+class NotificationServiceTest {
+
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@InjectMocks
+	private NotificationService notificationService;
+
+	private User testUser;
+	private List<Notification> testNotifications;
+	private static final Long USER_ID = 1L;
+	private static final Long OTHER_USER_ID = 2L;
+	private static final Long NOTIFICATION_ID = 100L;
+
+	@BeforeEach
+	void setUp() {
+		// 테스트 사용자 생성
+		testUser = User.builder()
+			.email("test@test.com")
+			.nickname("tester")
+			.password("encoded_password")
+			.fullName("Test User")
+			.role(UserRole.NORMAL)
+			.activeStatus(UserActiveStatus.ACTIVE)
+			.build();
+
+		// Reflection을 사용하여 User ID 설정 (테스트용)
+		setId(testUser, USER_ID);
+
+		// 테스트 알림 데이터 생성 (안읽은 3개, 읽은 2개)
+		testNotifications = createTestNotifications();
+	}
+
+	/**
+	 * 테스트용 알림 데이터 생성
+	 */
+	private List<Notification> createTestNotifications() {
+		List<Notification> notifications = new ArrayList<>();
+
+		// 안읽은 알림 3개
+		for (int i = 1; i <= 3; i++) {
+			notifications.add(createNotification(
+				(long)i,
+				"알림 제목 " + i,
+				"알림 내용 " + i,
+				false
+			));
+		}
+
+		// 읽은 알림 2개
+		for (int i = 4; i <= 5; i++) {
+			Notification notification = createNotification(
+				(long)i,
+				"알림 제목 " + i,
+				"알림 내용 " + i,
+				false
+			);
+			notification.markAsRead();
+			notifications.add(notification);
+		}
+
+		return notifications;
+	}
+
+	/**
+	 * 알림 생성 헬퍼 메서드
+	 */
+	private Notification createNotification(Long id, String title, String message, boolean isRead) {
+		Notification notification = Notification.builder()
+			.user(testUser)
+			.type(NotificationTypes.PAYMENT)
+			.typeDetail(NotificationTypeDetails.PAYMENT_SUCCESS)
+			.fromWhere(DomainName.ORDERS)
+			.whereId(1L)
+			.title(title)
+			.message(message)
+			.isRead(isRead)
+			.build();
+
+		// Reflection을 사용하여 ID 설정 (테스트용)
+		setId(notification, id);
+
+		return notification;
+	}
+
+	/**
+	 * Reflection을 사용하여 엔티티 ID 설정 (테스트용)
+	 */
+	private void setId(Object entity, Long id) {
+		try {
+			var idField = entity.getClass().getDeclaredField("id");
+			idField.setAccessible(true);
+			idField.set(entity, id);
+		} catch (Exception e) {
+			throw new RuntimeException("ID 설정 실패: " + entity.getClass().getSimpleName(), e);
+		}
+	}
+
+	@Nested
+	@DisplayName("getNotifications 테스트")
+	class GetNotificationsTest {
+
+		@Test
+		@DisplayName("알림 목록 조회 성공 - 5개 반환")
+		void getNotifications_Success() {
+			// given
+			given(notificationRepository.findByUserIdOrderByCreateAtDesc(USER_ID))
+				.willReturn(testNotifications);
+
+			// when
+			List<NotificationResponseDto> result = notificationService.getNotifications(USER_ID);
+
+			// then
+			assertThat(result).hasSize(5);
+			assertThat(result).extracting("title")
+				.containsExactly("알림 제목 1", "알림 제목 2", "알림 제목 3", "알림 제목 4", "알림 제목 5");
+			verify(notificationRepository, times(1))
+				.findByUserIdOrderByCreateAtDesc(USER_ID);
+		}
+
+		@Test
+		@DisplayName("알림이 없는 경우 - 빈 리스트 반환")
+		void getNotifications_EmptyList() {
+			// given
+			given(notificationRepository.findByUserIdOrderByCreateAtDesc(USER_ID))
+				.willReturn(List.of());
+
+			// when
+			List<NotificationResponseDto> result = notificationService.getNotifications(USER_ID);
+
+			// then
+			assertThat(result).isEmpty();
+			verify(notificationRepository, times(1))
+				.findByUserIdOrderByCreateAtDesc(USER_ID);
+		}
+
+		@Test
+		@DisplayName("알림 내용 검증 - DTO 변환 정확성")
+		void getNotifications_DtoMapping() {
+			// given
+			Notification notification = testNotifications.get(0);
+			given(notificationRepository.findByUserIdOrderByCreateAtDesc(USER_ID))
+				.willReturn(List.of(notification));
+
+			// when
+			List<NotificationResponseDto> result = notificationService.getNotifications(USER_ID);
+
+			// then
+			assertThat(result).hasSize(1);
+			NotificationResponseDto dto = result.get(0);
+			assertThat(dto.id()).isEqualTo(notification.getId());
+			assertThat(dto.title()).isEqualTo(notification.getTitle());
+			assertThat(dto.message()).isEqualTo(notification.getMessage());
+			assertThat(dto.type()).isEqualTo(notification.getType().name());
+			assertThat(dto.typeDetail()).isEqualTo(notification.getTypeDetail().name());
+			assertThat(dto.isRead()).isEqualTo(notification.isRead());
+		}
+	}
+
+	@Nested
+	@DisplayName("getUnreadCount 테스트")
+	class GetUnreadCountTest {
+
+		@Test
+		@DisplayName("안읽은 알림 개수 조회 성공 - 3개")
+		void getUnreadCount_Success() {
+			// given
+			given(notificationRepository.countByUserIdAndIsReadFalse(USER_ID))
+				.willReturn(3L);
+
+			// when
+			long result = notificationService.getUnreadCount(USER_ID);
+
+			// then
+			assertThat(result).isEqualTo(3L);
+			verify(notificationRepository, times(1))
+				.countByUserIdAndIsReadFalse(USER_ID);
+		}
+
+		@Test
+		@DisplayName("모든 알림을 읽은 경우 - 0 반환")
+		void getUnreadCount_AllRead() {
+			// given
+			given(notificationRepository.countByUserIdAndIsReadFalse(USER_ID))
+				.willReturn(0L);
+
+			// when
+			long result = notificationService.getUnreadCount(USER_ID);
+
+			// then
+			assertThat(result).isZero();
+			verify(notificationRepository, times(1))
+				.countByUserIdAndIsReadFalse(USER_ID);
+		}
+
+		@Test
+		@DisplayName("알림이 없는 경우 - 0 반환")
+		void getUnreadCount_NoNotifications() {
+			// given
+			given(notificationRepository.countByUserIdAndIsReadFalse(USER_ID))
+				.willReturn(0L);
+
+			// when
+			long result = notificationService.getUnreadCount(USER_ID);
+
+			// then
+			assertThat(result).isZero();
+			verify(notificationRepository, times(1))
+				.countByUserIdAndIsReadFalse(USER_ID);
+		}
+	}
+
+	@Nested
+	@DisplayName("markAsRead 테스트")
+	class MarkAsReadTest {
+
+		@Test
+		@DisplayName("알림 읽음 처리 성공")
+		void markAsRead_Success() {
+			// given
+			Notification unreadNotification = testNotifications.get(0); // 안읽은 알림
+			given(notificationRepository.findByIdAndUserId(NOTIFICATION_ID, USER_ID))
+				.willReturn(Optional.of(unreadNotification));
+
+			// when
+			notificationService.markAsRead(NOTIFICATION_ID, USER_ID);
+
+			// then
+			assertThat(unreadNotification.isRead()).isTrue();
+			assertThat(unreadNotification.getReadAt()).isNotNull();
+			verify(notificationRepository, times(1))
+				.findByIdAndUserId(NOTIFICATION_ID, USER_ID);
+		}
+
+		@Test
+		@DisplayName("이미 읽은 알림 재처리 - 멱등성")
+		void markAsRead_AlreadyRead() {
+			// given
+			Notification readNotification = testNotifications.get(3); // 이미 읽은 알림
+			assertThat(readNotification.isRead()).isTrue();
+
+			given(notificationRepository.findByIdAndUserId(NOTIFICATION_ID, USER_ID))
+				.willReturn(Optional.of(readNotification));
+
+			// when
+			notificationService.markAsRead(NOTIFICATION_ID, USER_ID);
+
+			// then
+			assertThat(readNotification.isRead()).isTrue();
+			verify(notificationRepository, times(1))
+				.findByIdAndUserId(NOTIFICATION_ID, USER_ID);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 알림 - 예외 발생")
+		void markAsRead_NotFound() {
+			// given
+			given(notificationRepository.findByIdAndUserId(NOTIFICATION_ID, USER_ID))
+				.willReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> notificationService.markAsRead(NOTIFICATION_ID, USER_ID))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("알림을 찾을 수 없습니다");
+
+			verify(notificationRepository, times(1))
+				.findByIdAndUserId(NOTIFICATION_ID, USER_ID);
+		}
+
+		@Test
+		@DisplayName("다른 사용자의 알림 접근 - 예외 발생")
+		void markAsRead_OtherUserNotification() {
+			// given
+			given(notificationRepository.findByIdAndUserId(NOTIFICATION_ID, OTHER_USER_ID))
+				.willReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> notificationService.markAsRead(NOTIFICATION_ID, OTHER_USER_ID))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("알림을 찾을 수 없습니다");
+
+			verify(notificationRepository, times(1))
+				.findByIdAndUserId(NOTIFICATION_ID, OTHER_USER_ID);
+		}
+	}
+
+	@Nested
+	@DisplayName("markAllAsRead 테스트")
+	class MarkAllAsReadTest {
+
+		@Test
+		@DisplayName("모든 알림 읽음 처리 성공 - 3개")
+		void markAllAsRead_Success() {
+			// given
+			List<Notification> unreadNotifications = testNotifications.subList(0, 3); // 안읽은 3개
+			given(notificationRepository.findByUserIdAndIsReadFalse(USER_ID))
+				.willReturn(unreadNotifications);
+
+			// when
+			notificationService.markAllAsRead(USER_ID);
+
+			// then
+			assertThat(unreadNotifications)
+				.allMatch(Notification::isRead)
+				.allMatch(n -> n.getReadAt() != null);
+
+			verify(notificationRepository, times(1))
+				.findByUserIdAndIsReadFalse(USER_ID);
+		}
+
+		@Test
+		@DisplayName("안읽은 알림이 없는 경우 - 정상 처리")
+		void markAllAsRead_NoUnreadNotifications() {
+			// given
+			given(notificationRepository.findByUserIdAndIsReadFalse(USER_ID))
+				.willReturn(List.of());
+
+			// when & then
+			assertThatCode(() -> notificationService.markAllAsRead(USER_ID))
+				.doesNotThrowAnyException();
+
+			verify(notificationRepository, times(1))
+				.findByUserIdAndIsReadFalse(USER_ID);
+		}
+
+		@Test
+		@DisplayName("일부만 안읽은 경우 - 안읽은 것만 처리")
+		void markAllAsRead_PartialUnread() {
+			// given
+			List<Notification> unreadNotifications = testNotifications.subList(0, 3); // 안읽은 3개
+			List<Notification> readNotifications = testNotifications.subList(3, 5); // 읽은 2개
+
+			// 읽은 알림의 초기 readAt 저장
+			List<LocalDateTime> originalReadAts = readNotifications.stream()
+				.map(Notification::getReadAt)
+				.toList();
+
+			given(notificationRepository.findByUserIdAndIsReadFalse(USER_ID))
+				.willReturn(unreadNotifications);
+
+			// when
+			notificationService.markAllAsRead(USER_ID);
+
+			// then
+			// 안읽은 알림만 읽음 처리됨
+			assertThat(unreadNotifications).allMatch(Notification::isRead);
+
+			// 이미 읽은 알림은 영향 없음 (readAt이 변경 안 됨)
+			for (int i = 0; i < readNotifications.size(); i++) {
+				assertThat(readNotifications.get(i).getReadAt())
+					.isEqualTo(originalReadAts.get(i));
+			}
+
+			verify(notificationRepository, times(1))
+				.findByUserIdAndIsReadFalse(USER_ID);
+		}
+	}
+}

--- a/backend/src/test/java/com/back/api/payment/service/PaymentServiceTest.java
+++ b/backend/src/test/java/com/back/api/payment/service/PaymentServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.back.api.payment.order.service.OrderService;
@@ -52,6 +53,9 @@ class PaymentServiceTest {
 
 	@Mock
 	private PasswordEncoder passwordEncoder;
+
+	@Mock
+	private ApplicationEventPublisher eventPublisher;
 
 	@Test
 	@DisplayName("결제 성공 - Order PAID, Ticket ISSUED, Seat SOLD")

--- a/backend/src/test/java/com/back/api/queue/service/QueueEntryProcessServiceTest.java
+++ b/backend/src/test/java/com/back/api/queue/service/QueueEntryProcessServiceTest.java
@@ -25,6 +25,7 @@ import com.back.api.queue.dto.response.EnteredQueueResponse;
 import com.back.api.queue.dto.response.ExpiredQueueResponse;
 import com.back.config.TestRedisConfig;
 import com.back.domain.event.entity.Event;
+import com.back.domain.event.repository.EventRepository;
 import com.back.domain.queue.entity.QueueEntry;
 import com.back.domain.queue.entity.QueueEntryStatus;
 import com.back.domain.queue.repository.QueueEntryRedisRepository;
@@ -57,6 +58,9 @@ class QueueEntryProcessServiceTest {
 	@Mock
 	private QueueEntryReadService queueEntryReadService;
 
+	@Mock
+	private EventRepository eventRepository;
+
 	private QueueSchedulerProperties queueSchedulerProperties;
 
 	private Event testEvent;
@@ -83,7 +87,8 @@ class QueueEntryProcessServiceTest {
 			queueEntryRedisRepository,
 			eventPublisher,
 			queueSchedulerProperties,
-			queueEntryReadService
+			queueEntryReadService,
+			eventRepository
 		);
 
 		testEvent = EventFactory.fakeEvent("TestEvent");


### PR DESCRIPTION
## 📌 개요
- 각 도메인에서 이벤트 발생(특정 상황 발생을 의미) -> 이벤트 퍼블리싱 -> 이벤트 리스닝 -> 알림 생성 -> 저장 및 웹소켓 전달
- 알림 조회 API
- 스프링 이벤트와 서비스에서의 이벤트 가 혼동될수 있을 것 같아 Message라는 이름으로 진행하였습니다
  - ex ) NotificationMessage, MessagingException.. 
<img width="1039" height="302" alt="image" src="https://github.com/user-attachments/assets/0bdda9fd-e3f6-4bee-b0c2-86d773261994" />

- 
---

## ✨ 작업 내용
- 이벤트 퍼블리싱 코드 추가
  - PaymentService, PreRegisterService, QueueEntryProcessService
- 이벤트별 퍼블리싱할 클래스 구현
  - NotificationMessage, OrderFailedMessage, OrderSuccessMessage, PreRegisterDoneMessage, QueueEntriesMessage, TicketGetMessage 
---
- 이벤트 리스너 구현
  - NotificationEventListener
  - 이벤트 listen 시 알림 엔티티 생성, 저장, 웹소켓 전달
---
- 웹소켓 설정 (WebSocketConfig) 
  - 특정 유저에게 보낼때 사용 하는 prefix ("/user") 추가 
  - webSocketAuthInterceptor (인터셉터) 추가 : STOMP 연결 시 Authorization헤더에서 JWT 검증 
    - ( 웹소켓 통신에서는 쿠키보다 헤더 사용하는것이 장점이 더 많다고 함 )
    - STOMP CONNECT 프레임 감지 -> 헤더에서 JWT 추출 -> JwtProvider로 검증 -> userId 추출하여 Principal 설정 -> 실패: MessagingException
- 웹소켓 엔드포인트: ws://localhost:8080/ws
- 알림 구독 경로: /user/notifications
---
- 사용자 온라인 여부 체크 ( userId 와 sessionId 를 매핑 )
  - addSession(userId, sessionId) - 연결 시 저장
  - removeSession(userId) - 연결 해제 시 삭제
  - isUserOnline(userId) - 온라인 여부 확인
  - SessionConnectedEvent / SessionDisconnectEvent 리스너
  - 데이터 구조:
  private final ConcurrentHashMap<Long, String> userSessions;
  // userId → sessionId
---
- 알림 API 구현
  - 알림 전체 조회 -  GET /api/v1/notifications
  - 읽지 않은 알림 개수 조회 - GET /api/v1/notifications/unread/count
  - 알림 개별 읽음 처리 - PATCH /api/v1/notifications/{id}/read
  - 알림 전체 읽음 처리 - PATCH /api/v1/notifications/read-all
- 응답 DTO
  - NotificationResponseDto - 알림 정보
  - UnreadCountResponseDto - 읽지 않은 알림 개수
---

## 🔗 관련 이슈
- close #28   

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결