### PR TITLE
[refactor] 사용자 권한에 따른 보안 정책 분리

### DIFF
--- a/backend/src/main/java/com/back/global/error/code/AuthErrorCode.java
+++ b/backend/src/main/java/com/back/global/error/code/AuthErrorCode.java
@@ -13,6 +13,9 @@ public enum AuthErrorCode implements ErrorCode {
 
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인 후 이용해주세요."),
 
+	FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+	ADMIN_ONLY(HttpStatus.FORBIDDEN, "관리자 계정만 접근 가능합니다."),
+
 	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 	REFRESH_TOKEN_REQUIRED(HttpStatus.BAD_REQUEST, "리프레시 토큰이 없습니다."),

--- a/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -31,8 +31,6 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class CustomAuthenticationFilter extends OncePerRequestFilter {
-
-	private static final String AUTH_PATH_PREFIX = "/api/v1/auth/";
 	private static final String BEARER_PREFIX = "Bearer ";
 
 	private static final Set<String> AUTH_WHITELIST = Set.of(
@@ -93,7 +91,14 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 
 		long userId = ((Number)payload.get("id")).longValue();
 		String nickname = (String)payload.getOrDefault("nickname", "");
-		UserRole role = (UserRole)payload.getOrDefault("role", UserRole.NORMAL);
+		Object roleObj = payload.get("role");
+		UserRole role = UserRole.NORMAL;
+
+		if (roleObj instanceof String roleStr) {
+			role = UserRole.valueOf(roleStr);
+		} else if (roleObj instanceof UserRole userRole) {
+			role = userRole;
+		}
 
 		SecurityUser securityUser = new SecurityUser(
 			userId,

--- a/backend/src/main/java/com/back/global/security/JwtProvider.java
+++ b/backend/src/main/java/com/back/global/security/JwtProvider.java
@@ -60,7 +60,7 @@ public class JwtProvider {
 		Map<String, Object> claims = new HashMap<>();
 		claims.put(CLAIM_ID, user.getId());
 		claims.put(CLAIM_NICKNAME, user.getNickname());
-		claims.put(CLAIM_ROLE, user.getRole());
+		claims.put(CLAIM_ROLE, user.getRole().name());
 		return claims;
 	}
 


### PR DESCRIPTION
## 📌 개요
- 사용자 권한에 따른 보안 정책 분리 (ADMIN, NORMAL 사용자 API 정책 분리)

---

## ✨ 작업 내용
- SecurityConfig에서 NORMAL사용자와 ADMIN 사용자가 접근 가능한 API 분리 설정

---

## 🔗 관련 이슈
- close #109  

---

## 🧪 체크리스트
- [ ] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [ ] 팀 내 코드 스타일 준수
- [ ] 이슈 연결
