### PR TITLE
[fix] deploy에서는 비밀번호 사용하도록 RedisConfig 수정

### DIFF
--- a/backend/src/main/java/com/back/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/back/global/config/RedisConfig.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
@@ -18,9 +20,19 @@ public class RedisConfig {
 	@Value("${spring.data.redis.port}")
 	private int port;
 
+	@Value("${spring.data.redis.password:}")
+	private String password;
+
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(host, port);
+		RedisStandaloneConfiguration config =
+			new RedisStandaloneConfiguration(host, port);
+
+		if (password != null && !password.isBlank()) {
+			config.setPassword(RedisPassword.of(password));
+		}
+
+		return new LettuceConnectionFactory(config);
 	}
 
 	@Bean

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
     redis:
       host: localhost
       port: 6379
-      password: ${REDIS_PASSWORD}
+      password: ${REDIS_PASSWORD:}
 
 logging:
   level:


### PR DESCRIPTION
## 📌 개요
- 기존 RedisConfig 파일에서 비밀번호 관련 설정이 누락되어있어서 해당 부분 추가하였습니다.

---

## ✨ 작업 내용
- RedisConfig 수정
- RedisConnectionFactory 생성 시 비밀번호가 있으면 AUTH, 없으면 그냥 연결
- 개발 환경에서는 비밀번호 null

---

## 🔗 관련 이슈
- close #138

---

## 🧪 체크리스트
- [ ] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [ ] 팀 내 코드 스타일 준수
- [ ] 이슈 연결
