### PR TITLE
[fix] doppler 접근 시 env 파일 생성 대신 바로 접근하는 방식으로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,18 +116,27 @@ jobs:
           working-directory: /
           comment: Deploy
           command: |
+
+            export DOPPLER_TOKEN="${{ secrets.DOPPLER_TOKEN }}"
+
             docker pull ghcr.io/${{ needs.buildImageAndPush.outputs.owner_lc }}/${{ needs.buildImageAndPush.outputs.image_name }}:latest
-            
+
             docker stop app1 2>/dev/null || true
             docker rm app1 2>/dev/null || true
-            
-            export DOPPLER_TOKEN="${{ secrets.DOPPLER_TOKEN }}"
-            doppler secrets download --project waitfair --config prd --format env-no-quotes --no-file > /tmp/doppler.env
+
+            doppler secrets download \
+              --project waitfair \
+              --config prd \
+              --format env-no-quotes \
+              --no-file \
+            | docker run -d \
+                --name app1 \
+                --restart unless-stopped \
+                --network common \
+                -p 8080:8080 \
+                --env-file /dev/stdin \
+                ghcr.io/${{ needs.buildImageAndPush.outputs.owner_lc }}/${{ needs.buildImageAndPush.outputs.image_name }}:latest
+
             unset DOPPLER_TOKEN
-            
-            docker run -d --name app1 --network common -p 8080:8080 \
-              --env-file /tmp/doppler.env \
-              ghcr.io/${{ needs.buildImageAndPush.outputs.owner_lc }}/${{ needs.buildImageAndPush.outputs.image_name }}:latest
-            
-            rm -f /tmp/doppler.env
+
             docker image prune -f


### PR DESCRIPTION
## 📌 개요
- 기존 env 파일을 생성하는 방식에서는 종종 오류가 발생하여 doppler run을 통해 바로 doppler에 접근하여 환경 변수를 사용하는 방식으로 변경하였습니다.
- doppler CLI가 EC2 터미널에 설치되어있다는 것을 가정하고 진행
---

## ✨ 작업 내용
- deploy.yml 수정

---

## 🔗 관련 이슈
- close #140

---

## 🧪 체크리스트
- [ ] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [ ] 팀 내 코드 스타일 준수
- [ ] 이슈 연결
