### PR TITLE
[fix] globalExceptionHandler contentType 지정

### DIFF
--- a/backend/src/main/java/com/back/global/error/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/back/global/error/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.back.global.error.handler;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -21,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
+
 	// 커스텀 예외 처리
 	@ExceptionHandler(ErrorException.class)
 	protected ResponseEntity<ApiResponse<?>> handleCustomException(ErrorException ex) {
@@ -35,6 +37,7 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity
 			.status(code.getHttpStatus())
+			.contentType(MediaType.APPLICATION_JSON)
 			.body(ApiResponse.fail(code.getHttpStatus(), ex.getMessage()));
 	}
 
@@ -56,6 +59,7 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity
 			.status(code.getHttpStatus())
+			.contentType(MediaType.APPLICATION_JSON)
 			.body(ApiResponse.fail(code.getHttpStatus(), message));
 	}
 
@@ -67,6 +71,7 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity
 			.status(code.getHttpStatus())
+			.contentType(MediaType.APPLICATION_JSON)
 			.body(ApiResponse.fail(code));
 	}
 
@@ -78,6 +83,7 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity
 			.status(code.getHttpStatus())
+			.contentType(MediaType.APPLICATION_JSON)
 			.body(ApiResponse.fail(code));
 	}
 
@@ -89,6 +95,7 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity
 			.status(code.getHttpStatus())
+			.contentType(MediaType.APPLICATION_JSON)
 			.body(ApiResponse.fail(code));
 	}
 
@@ -100,6 +107,7 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity
 			.status(code.getHttpStatus())
+			.contentType(MediaType.APPLICATION_JSON)
 			.body(ApiResponse.fail(code));
 	}
 
@@ -122,6 +130,7 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity
 			.status(code.getHttpStatus())
+			.contentType(MediaType.APPLICATION_JSON)
 			.body(ApiResponse.fail(code));
 	}
 
@@ -133,6 +142,7 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity
 			.status(code.getHttpStatus())
+			.contentType(MediaType.APPLICATION_JSON)
 			.body(ApiResponse.fail(code.getHttpStatus(), ex.getMessage()));
 	}
 
@@ -144,6 +154,7 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity
 			.status(code.getHttpStatus())
+			.contentType(MediaType.APPLICATION_JSON)
 			.body(ApiResponse.fail(code));
 	}
 }


### PR DESCRIPTION
## 📌 개요
- 배포 서버 로그에서 뜨던 GlobalExceptionHandler 관련 오류를 수정하였습니다.
- 기존 반환 타입이 json으로 지정되어있지 않아서 생기는 문제로 추정되어, contentType json으로 지정하였습니다.
<img width="1242" height="57" alt="image" src="https://github.com/user-attachments/assets/0a59d944-2236-4f90-8595-c4ebc3692cc4" />

---

## ✨ 작업 내용
- GlobalExceptionHandler 수정

---

## 🔗 관련 이슈
- close #154

---

## 🧪 체크리스트
- [ ] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [ ] 팀 내 코드 스타일 준수
- [ ] 이슈 연결
