### PR TITLE
[feat] 인증 없는 사전 등록 추가

### DIFF
--- a/backend/src/main/java/com/back/api/preregister/controller/PreRegisterApi.java
+++ b/backend/src/main/java/com/back/api/preregister/controller/PreRegisterApi.java
@@ -1,9 +1,7 @@
 package com.back.api.preregister.controller;
 
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 
-import com.back.api.preregister.dto.request.PreRegisterCreateRequest;
 import com.back.api.preregister.dto.response.PreRegisterResponse;
 import com.back.global.config.swagger.ApiErrorCode;
 import com.back.global.response.ApiResponse;
@@ -12,14 +10,35 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 
 @Tag(name = "PreRegister API", description = "사전등록 API")
 public interface PreRegisterApi {
 
+	// 인증 있는 사전 등록 -> v2에서 사용 예정
+	// @Operation(
+	// 	summary = "사전등록",
+	// 	description = "이벤트에 사전등록합니다. 휴대폰 번호, 생년월일을 통한 본인 인증이 필요하며, 약관 동의가 필수입니다. 이름은 JWT 토큰으로 인증된 사용자 정보에서 자동으로 가져옵니다.",
+	// 	security = @SecurityRequirement(name = "bearerAuth")
+	// )
+	// @ApiErrorCode({
+	// 	"NOT_FOUND_EVENT",
+	// 	"NOT_FOUND_USER",
+	// 	"ALREADY_PRE_REGISTERED",
+	// 	"INVALID_PRE_REGISTRATION_PERIOD",
+	// 	"INVALID_USER_INFO",
+	// 	"TERMS_NOT_AGREED",
+	// 	"PRIVACY_NOT_AGREED",
+	// 	"UNAUTHORIZED"
+	// })
+	// ApiResponse<PreRegisterResponse> register(
+	// 	@Parameter(description = "이벤트 ID", example = "1")
+	// 	@PathVariable Long eventId,
+	// 	@Valid @RequestBody PreRegisterCreateRequest request
+	// );
+
 	@Operation(
 		summary = "사전등록",
-		description = "이벤트에 사전등록합니다. 휴대폰 번호, 생년월일을 통한 본인 인증이 필요하며, 약관 동의가 필수입니다. 이름은 JWT 토큰으로 인증된 사용자 정보에서 자동으로 가져옵니다.",
+		description = "이벤트에 사전등록합니다. (인증 제외)",
 		security = @SecurityRequirement(name = "bearerAuth")
 	)
 	@ApiErrorCode({
@@ -34,8 +53,7 @@ public interface PreRegisterApi {
 	})
 	ApiResponse<PreRegisterResponse> register(
 		@Parameter(description = "이벤트 ID", example = "1")
-		@PathVariable Long eventId,
-		@Valid @RequestBody PreRegisterCreateRequest request
+		@PathVariable Long eventId
 	);
 
 	@Operation(

--- a/backend/src/main/java/com/back/api/preregister/controller/PreRegisterController.java
+++ b/backend/src/main/java/com/back/api/preregister/controller/PreRegisterController.java
@@ -4,17 +4,14 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.back.api.preregister.dto.request.PreRegisterCreateRequest;
 import com.back.api.preregister.dto.response.PreRegisterResponse;
 import com.back.api.preregister.service.PreRegisterService;
 import com.back.global.http.HttpRequestContext;
 import com.back.global.response.ApiResponse;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -25,13 +22,22 @@ public class PreRegisterController implements PreRegisterApi {
 	private final PreRegisterService preRegisterService;
 	private final HttpRequestContext httpRequestContext;
 
+	// 인증 있는 사전 등록 -> v2에서 사용 예정
+	// @Override
+	// @PostMapping
+	// public ApiResponse<PreRegisterResponse> register(
+	// 	@PathVariable Long eventId,
+	// 	@Valid @RequestBody PreRegisterCreateRequest request) {
+	// 	Long userId = httpRequestContext.getUserId();
+	// 	PreRegisterResponse response = preRegisterService.register(eventId, userId, request);
+	// 	return ApiResponse.created("사전등록이 완료되었습니다.", response);
+	// }
+
 	@Override
 	@PostMapping
-	public ApiResponse<PreRegisterResponse> register(
-		@PathVariable Long eventId,
-		@Valid @RequestBody PreRegisterCreateRequest request) {
+	public ApiResponse<PreRegisterResponse> register(@PathVariable Long eventId) {
 		Long userId = httpRequestContext.getUserId();
-		PreRegisterResponse response = preRegisterService.register(eventId, userId, request);
+		PreRegisterResponse response = preRegisterService.quickPreRegister(eventId, userId);
 		return ApiResponse.created("사전등록이 완료되었습니다.", response);
 	}
 


### PR DESCRIPTION
## 📌 개요
- 프론트 회의를 통한 인증 없는 사전 등록 API로 수정 작업 진행하였습니다.
- 참고로 기존 코드는 주석 처리하였습니다.
- API는 동일한 API를 사용하기 때문에 테스트 코드에서 오류가 날 수 있지만 일단 빠른 협업을 위해 코드만 수정했습니다.

---

## ✨ 작업 내용
- 

---

## 🔗 관련 이슈
- close #161

---

## 🧪 체크리스트
- [ ] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [ ] 팀 내 코드 스타일 준수
- [ ] 이슈 연결
