### PR TITLE
[refactor] ActiveSession 엔티티를 추가하여, 사용자의 다중 로그인을 방지

### DIFF
--- a/backend/src/main/java/com/back/api/auth/service/AuthTokenService.java
+++ b/backend/src/main/java/com/back/api/auth/service/AuthTokenService.java
@@ -1,15 +1,22 @@
 package com.back.api.auth.service;
 
 import java.time.LocalDateTime;
-import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.back.api.auth.dto.JwtDto;
+import com.back.domain.auth.entity.ActiveSession;
 import com.back.domain.auth.entity.RefreshToken;
+import com.back.domain.auth.repository.ActiveSessionRepository;
 import com.back.domain.auth.repository.RefreshTokenRepository;
 import com.back.domain.user.entity.User;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.error.code.AuthErrorCode;
+import com.back.global.error.exception.ErrorException;
 import com.back.global.http.HttpRequestContext;
+import com.back.global.security.JwtClaims;
 import com.back.global.security.JwtProvider;
 
 import lombok.RequiredArgsConstructor;
@@ -20,11 +27,14 @@ public class AuthTokenService {
 
 	private final JwtProvider jwtProvider;
 	private final RefreshTokenRepository tokenRepository;
+	private final ActiveSessionRepository activeSessionRepository;
+	private final UserRepository userRepository;
 	private final HttpRequestContext requestContext;
 
-	public JwtDto generateTokens(User user) {
-		String accessToken = jwtProvider.generateAccessToken(user);
-		String refreshTokenStr = jwtProvider.generateRefreshToken(user);
+	@Transactional
+	public JwtDto issueTokens(User user, String sessionId, long tokenVersion) {
+		String accessToken = jwtProvider.generateAccessToken(user, sessionId, tokenVersion);
+		String refreshTokenStr = jwtProvider.generateRefreshToken(user, sessionId, tokenVersion);
 
 		// === seconds 기준 ===
 		long accessValiditySeconds = jwtProvider.getAccessTokenValiditySeconds();
@@ -37,17 +47,16 @@ public class AuthTokenService {
 		// === DB 저장용 만료 시각 (LocalDateTime) ===
 		LocalDateTime expiresAt = issuedAt.plusSeconds(refreshValiditySeconds);
 
-		String userAgent = requestContext.getUserAgent();
-		String ip = requestContext.getClientIp();
-
 		RefreshToken refreshToken = RefreshToken.builder()
 			.user(user)
 			.token(refreshTokenStr)
 			.issuedAt(issuedAt)
 			.expiresAt(expiresAt)
 			.revoked(false)
-			.userAgent(userAgent)
-			.ipAddress(ip)
+			.userAgent(requestContext.getUserAgent())
+			.ipAddress(requestContext.getClientIp())
+			.sessionId(sessionId)
+			.tokenVersion(tokenVersion)
 			.build();
 
 		tokenRepository.save(refreshToken);
@@ -67,7 +76,41 @@ public class AuthTokenService {
 		);
 	}
 
-	public Map<String, Object> payloadOrNull(String accessToken) {
-		return jwtProvider.payloadOrNull(accessToken);
+	@Transactional
+	public JwtDto rotateTokenByRefreshToken(String refreshTokenStr) {
+		if (StringUtils.isBlank(refreshTokenStr)) {
+			throw new ErrorException(AuthErrorCode.REFRESH_TOKEN_REQUIRED);
+		}
+
+		if (jwtProvider.isExpired(refreshTokenStr)) {
+			throw new ErrorException(AuthErrorCode.TOKEN_EXPIRED);
+		}
+
+		JwtClaims claims = jwtProvider.payloadOrNull(refreshTokenStr);
+
+		if (claims == null || !"refresh".equals(claims.tokenType())) {
+			throw new ErrorException(AuthErrorCode.INVALID_TOKEN);
+		}
+
+		long userId = claims.userId();
+		String sid = claims.sessionId();
+		long tokenVersion = claims.tokenVersion();
+
+		ActiveSession active = activeSessionRepository.findByUserIdForUpdate(userId)
+			.orElseThrow(() -> new ErrorException(AuthErrorCode.UNAUTHORIZED));
+
+		if (!active.getSessionId().equals(sid) || active.getTokenVersion() != tokenVersion) {
+			throw new ErrorException(AuthErrorCode.ACCESS_OTHER_DEVICE);
+		}
+
+		int revoked = tokenRepository.revokeIfActive(refreshTokenStr);
+		if (revoked != 1) {
+			throw new ErrorException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
+		}
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new ErrorException(AuthErrorCode.UNAUTHORIZED));
+
+		return issueTokens(user, active.getSessionId(), active.getTokenVersion());
 	}
 }

--- a/backend/src/main/java/com/back/domain/auth/entity/ActiveSession.java
+++ b/backend/src/main/java/com/back/domain/auth/entity/ActiveSession.java
@@ -1,0 +1,82 @@
+package com.back.domain.auth.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.back.domain.user.entity.User;
+import com.back.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "activeSessions",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_active_session_user", columnNames = {"user_id"})
+	},
+	indexes = {
+		@Index(name = "idx_active_session_session_id", columnList = "session_id")
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActiveSession extends BaseEntity {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(name = "session_id", nullable = false, length = 36)
+	private String sessionId;
+
+	@Column(name = "token_version", nullable = false)
+	private long tokenVersion;
+
+	@Column(name = "last_login_at", nullable = false)
+	private LocalDateTime lastLoginAt;
+
+	@Builder
+	private ActiveSession(
+		User user,
+		String sessionId,
+		long tokenVersion,
+		LocalDateTime lastLoginAt
+	) {
+		this.user = user;
+		this.sessionId = sessionId;
+		this.tokenVersion = tokenVersion;
+		this.lastLoginAt = lastLoginAt;
+	}
+
+	public static ActiveSession create(User user) {
+		return ActiveSession.builder()
+			.user(user)
+			.sessionId(UUID.randomUUID().toString())
+			.tokenVersion(1L)
+			.lastLoginAt(LocalDateTime.now())
+			.build();
+	}
+
+	public void rotate() {
+		this.sessionId = UUID.randomUUID().toString();
+		this.tokenVersion += 1;
+		this.lastLoginAt = LocalDateTime.now();
+	}
+}

--- a/backend/src/main/java/com/back/domain/auth/entity/RefreshToken.java
+++ b/backend/src/main/java/com/back/domain/auth/entity/RefreshToken.java
@@ -49,6 +49,12 @@ public class RefreshToken extends BaseEntity {
 	@Column(name = "expires_at")
 	private LocalDateTime expiresAt;
 
+	@Column(name = "session_id", length = 36)
+	private String sessionId;
+
+	@Column(name = "token_version")
+	private Long tokenVersion;
+
 	private boolean revoked; // 기기 로그아웃 확인
 
 	private String userAgent;
@@ -61,6 +67,8 @@ public class RefreshToken extends BaseEntity {
 		String token,
 		LocalDateTime issuedAt,
 		LocalDateTime expiresAt,
+		String sessionId,
+		long tokenVersion,
 		boolean revoked,
 		String userAgent,
 		String ipAddress
@@ -69,6 +77,8 @@ public class RefreshToken extends BaseEntity {
 		this.token = token;
 		this.issuedAt = issuedAt;
 		this.expiresAt = expiresAt;
+		this.sessionId = sessionId;
+		this.tokenVersion = tokenVersion;
 		this.revoked = revoked;
 		this.userAgent = userAgent;
 		this.ipAddress = ipAddress;
@@ -76,15 +86,5 @@ public class RefreshToken extends BaseEntity {
 
 	public void revoke() {
 		this.revoked = true;
-	}
-
-	public void updateRefreshToken(
-		String newToken,
-		LocalDateTime newIssuedAt,
-		LocalDateTime newExpiresAt
-	) {
-		this.token = newToken;
-		this.issuedAt = newIssuedAt;
-		this.expiresAt = newExpiresAt;
 	}
 }

--- a/backend/src/main/java/com/back/domain/auth/repository/ActiveSessionRepository.java
+++ b/backend/src/main/java/com/back/domain/auth/repository/ActiveSessionRepository.java
@@ -1,0 +1,21 @@
+package com.back.domain.auth.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.back.domain.auth.entity.ActiveSession;
+
+import jakarta.persistence.LockModeType;
+
+public interface ActiveSessionRepository extends JpaRepository<ActiveSession, Long> {
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT s FROM ActiveSession s WHERE s.user.id = :userId")
+	Optional<ActiveSession> findByUserIdForUpdate(@Param("userId") long userId);
+
+	Optional<ActiveSession> findByUserId(long userId);
+}

--- a/backend/src/main/java/com/back/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/back/domain/auth/repository/RefreshTokenRepository.java
@@ -21,5 +21,22 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 	@Query("update RefreshToken rt set rt.revoked = true where rt.user.id = :userId and rt.revoked = false")
 	int revokeAllByUserId(@Param("userId") Long userId);
 
+	@Modifying
+	@Query("""
+			UPDATE RefreshToken rt
+			set rt.revoked = true
+			where rt.token = :token
+			and rt.revoked = false
+		""")
+	int revokeIfActive(@Param("token") String token);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("""
+			update RefreshToken rt
+			set rt.revoked = true
+			where rt.user.id = :userId and rt.revoked = false
+		""")
+	int revokeAllActiveByUserId(@Param("userId") long userId);
+
 	Optional<RefreshToken> findByUserIdAndRevokedFalse(Long userId);
 }

--- a/backend/src/main/java/com/back/global/error/code/AuthErrorCode.java
+++ b/backend/src/main/java/com/back/global/error/code/AuthErrorCode.java
@@ -12,6 +12,7 @@ public enum AuthErrorCode implements ErrorCode {
 	ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
 
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인 후 이용해주세요."),
+	ACCESS_OTHER_DEVICE(HttpStatus.UNAUTHORIZED, "다른 환경에서 로그인했습니다."),
 
 	FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 	ADMIN_ONLY(HttpStatus.FORBIDDEN, "관리자 계정만 접근 가능합니다."),

--- a/backend/src/main/java/com/back/global/security/JwtClaims.java
+++ b/backend/src/main/java/com/back/global/security/JwtClaims.java
@@ -1,0 +1,14 @@
+package com.back.global.security;
+
+import com.back.domain.user.entity.UserRole;
+
+public record JwtClaims(
+	long userId,
+	String nickname,
+	UserRole role,
+	String tokenType,
+	String jti,
+	String sessionId,
+	long tokenVersion
+) {
+}

--- a/backend/src/main/java/com/back/global/websocket/auth/WebSocketAuthInterceptor.java
+++ b/backend/src/main/java/com/back/global/websocket/auth/WebSocketAuthInterceptor.java
@@ -1,7 +1,5 @@
 package com.back.global.websocket.auth;
 
-import java.util.Map;
-
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -10,6 +8,7 @@ import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
+import com.back.global.security.JwtClaims;
 import com.back.global.security.JwtProvider;
 
 import lombok.RequiredArgsConstructor;
@@ -50,13 +49,13 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
 			}
 
 			// JWT 파싱 및 userId 추출
-			Map<String, Object> payload = jwtProvider.payloadOrNull(token);
-			if (payload == null) {
+			JwtClaims claims = jwtProvider.payloadOrNull(token);
+			if (claims == null) {
 				log.warn("웹소켓 연결 거부 - JWT 파싱 실패");
 				throw new IllegalArgumentException("유효하지 않은 토큰입니다");
 			}
 
-			Long userId = ((Number) payload.get("id")).longValue();
+			Long userId = claims.userId();
 
 			// Principal 설정 (convertAndSendToUser에서 사용)
 			accessor.setUser(new UserPrincipal(userId));

--- a/backend/src/test/java/com/back/api/auth/CustomAuthenticationFilterExpiredBothTest.java
+++ b/backend/src/test/java/com/back/api/auth/CustomAuthenticationFilterExpiredBothTest.java
@@ -1,0 +1,81 @@
+package com.back.api.auth;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserRole;
+import com.back.global.error.code.AuthErrorCode;
+import com.back.global.error.exception.ErrorException;
+import com.back.global.security.CustomAuthenticationFilter;
+import com.back.global.security.JwtProvider;
+import com.back.support.data.TestUser;
+import com.back.support.helper.UserHelper;
+
+import jakarta.servlet.http.Cookie;
+
+@SpringBootTest(properties = {
+	"custom.jwt.access-token-duration=0",
+	"custom.jwt.refresh-token-duration=0"
+})
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+public class CustomAuthenticationFilterExpiredBothTest {
+
+	@Autowired
+	private CustomAuthenticationFilter filter;
+
+	@Autowired
+	private UserHelper userHelper;
+
+	@Autowired
+	private JwtProvider jwtProvider;
+
+	@Value("${custom.jwt.secret}")
+	private String secret;
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("accessToken, refreshToken 모두 만료되면 TOKEN_EXPIRED 에러가 발생한다")
+	void token_expired_when_both_access_and_refresh_invalid() {
+		TestUser testUser = userHelper.createUser(UserRole.NORMAL);
+		User user = testUser.user();
+
+		String sid = "test-sid";
+		long tokenVersion = 1L;
+
+		String accessToken = jwtProvider.generateAccessToken(user, sid, tokenVersion);
+		String refreshToken = jwtProvider.generateRefreshToken(user, sid, tokenVersion);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/some-resource");
+		request.setCookies(
+			new Cookie("accessToken", accessToken),
+			new Cookie("refreshToken", refreshToken)
+		);
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain chain = new MockFilterChain();
+
+		org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+				filter.doFilter(request, response, chain)
+			).isInstanceOf(ErrorException.class)
+			.extracting("errorCode")
+			.isEqualTo(AuthErrorCode.TOKEN_EXPIRED);
+	}
+}

--- a/backend/src/test/java/com/back/api/auth/CustomAuthenticationFilterReissueTest.java
+++ b/backend/src/test/java/com/back/api/auth/CustomAuthenticationFilterReissueTest.java
@@ -3,7 +3,6 @@ package com.back.api.auth;
 import static org.assertj.core.api.Assertions.*;
 
 import java.io.IOException;
-import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,25 +17,30 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.back.api.auth.dto.JwtDto;
+import com.back.api.auth.service.AuthTokenService;
+import com.back.domain.auth.entity.ActiveSession;
+import com.back.domain.auth.repository.ActiveSessionRepository;
 import com.back.domain.user.entity.User;
 import com.back.domain.user.entity.UserRole;
-import com.back.global.error.code.AuthErrorCode;
-import com.back.global.error.exception.ErrorException;
 import com.back.global.security.CustomAuthenticationFilter;
-import com.back.global.security.JwtProvider;
 import com.back.global.security.SecurityUser;
-import com.back.global.utils.JwtUtil;
 import com.back.support.data.TestUser;
 import com.back.support.helper.UserHelper;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+	"custom.jwt.access-token-duration=1",
+	"custom.jwt.refresh-token-duration=60"
+})
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-public class CustomAuthenticationFilterTest {
+@Transactional
+public class CustomAuthenticationFilterReissueTest {
 
 	@Autowired
 	private CustomAuthenticationFilter filter;
@@ -45,7 +49,10 @@ public class CustomAuthenticationFilterTest {
 	private UserHelper userHelper;
 
 	@Autowired
-	private JwtProvider jwtProvider;
+	private AuthTokenService authTokenService;
+
+	@Autowired
+	private ActiveSessionRepository activeSessionRepository;
 
 	@Value("${custom.jwt.secret}")
 	private String secret;
@@ -57,31 +64,23 @@ public class CustomAuthenticationFilterTest {
 
 	@Test
 	@DisplayName("만료된 accessToken + 유효한 refreshToken 이 있으면 필터에서 토큰을 재발급하고 Authentication을 세팅한다")
-	void reissueTokensWhenAccessTokenExpiredAndRefreshTokenValid() throws ServletException, IOException {
+	void reissue_tokens_when_accessToken_expired_and_refresh_token_valid()
+		throws ServletException, IOException, InterruptedException {
 		// given
 		TestUser testUser = userHelper.createUser(UserRole.NORMAL);
 		User user = testUser.user();
 
-		Map<String, Object> payload = Map.of(
-			"id", user.getId(),
-			"nickname", user.getNickname(),
-			"role", user.getRole().name()
-		);
+		ActiveSession session = activeSessionRepository.save(ActiveSession.create(user));
+		String sid = session.getSessionId();
+		long tokenVersion = session.getTokenVersion();
 
-		// 이미 만료된 accessToken (유효기간을 음수로 줘서 발급 시점부터 만료 상태)
-		String expiredAccessToken = JwtUtil.toString(secret, -1L, payload);
-
-		// 아직 유효한 refreshToken
-		String validRefreshToken = JwtUtil.toString(
-			secret,
-			jwtProvider.getRefreshTokenValiditySeconds(),
-			payload
-		);
+		JwtDto tokens = authTokenService.issueTokens(user, sid, tokenVersion);
+		Thread.sleep(1100);
 
 		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/some-resource");
 		request.setCookies(
-			new Cookie("accessToken", expiredAccessToken),
-			new Cookie("refreshToken", validRefreshToken)
+			new Cookie("accessToken", tokens.accessToken()),
+			new Cookie("refreshToken", tokens.refreshToken())
 		);
 
 		MockHttpServletResponse response = new MockHttpServletResponse();
@@ -114,37 +113,6 @@ public class CustomAuthenticationFilterTest {
 
 		assertThat(newAccessToken).isNotBlank();
 		assertThat(newRefreshToken).isNotBlank();
-		assertThat(newAccessToken).isNotEqualTo(expiredAccessToken);
-	}
-
-	@Test
-	@DisplayName("accessToken, refreshToken 모두 만료되면 TOKEN_EXPIRED 에러가 발생한다")
-	void tokenExpiredWhenBothAccessAndRefreshInvalid() {
-		TestUser testUser = userHelper.createUser(UserRole.NORMAL);
-		User user = testUser.user();
-
-		Map<String, Object> payload = Map.of(
-			"id", user.getId(),
-			"nickname", user.getNickname(),
-			"role", user.getRole()
-		);
-
-		String expiredAccessToken = JwtUtil.toString(secret, -1L, payload);
-		String expiredRefreshToken = JwtUtil.toString(secret, -1L, payload);
-
-		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/some-resource");
-		request.setCookies(
-			new Cookie("accessToken", expiredAccessToken),
-			new Cookie("refreshToken", expiredRefreshToken)
-		);
-
-		MockHttpServletResponse response = new MockHttpServletResponse();
-		MockFilterChain chain = new MockFilterChain();
-
-		org.assertj.core.api.Assertions.assertThatThrownBy(() ->
-				filter.doFilter(request, response, chain)
-			).isInstanceOf(ErrorException.class)
-			.extracting("errorCode")
-			.isEqualTo(AuthErrorCode.TOKEN_EXPIRED);
+		assertThat(newAccessToken).isNotEqualTo(tokens.accessToken());
 	}
 }

--- a/backend/src/test/java/com/back/api/auth/MultiDeviceBlockAccessTokenTest.java
+++ b/backend/src/test/java/com/back/api/auth/MultiDeviceBlockAccessTokenTest.java
@@ -1,0 +1,96 @@
+package com.back.api.auth;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.api.auth.dto.JwtDto;
+import com.back.api.auth.service.AuthTokenService;
+import com.back.domain.auth.entity.ActiveSession;
+import com.back.domain.auth.repository.ActiveSessionRepository;
+import com.back.domain.auth.repository.RefreshTokenRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserRole;
+import com.back.global.error.code.AuthErrorCode;
+import com.back.global.error.exception.ErrorException;
+import com.back.global.security.CustomAuthenticationFilter;
+import com.back.support.data.TestUser;
+import com.back.support.helper.UserHelper;
+
+import jakarta.servlet.http.Cookie;
+
+@SpringBootTest(properties = {
+	"custom.jwt.access-token-duration=60",
+	"custom.jwt.refresh-token-duration=60"
+})
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+public class MultiDeviceBlockAccessTokenTest {
+
+	@Autowired
+	CustomAuthenticationFilter filter;
+
+	@Autowired
+	UserHelper userHelper;
+
+	@Autowired
+	AuthTokenService authTokenService;
+
+	@Autowired
+	ActiveSessionRepository activeSessionRepository;
+
+	@Autowired
+	RefreshTokenRepository refreshTokenRepository;
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("기기 B가 로그인(rotate)하면, 기기 A의 기존 accessToken 요청은 ACCESS_OTHER_DEVICE로 차단된다")
+	void block_old_access_token_after_other_device_login() throws Exception {
+		TestUser testUser = userHelper.createUser(UserRole.NORMAL);
+		User user = testUser.user();
+
+		ActiveSession session = activeSessionRepository
+			.findByUserId(user.getId())
+			.orElseGet(() -> activeSessionRepository.save(ActiveSession.create(user)));
+
+		String sidA = session.getSessionId();
+		long versionA = session.getTokenVersion();
+
+		JwtDto deviceATokens = authTokenService.issueTokens(user, sidA, versionA);
+
+		session.rotate();
+		activeSessionRepository.save(session);
+		refreshTokenRepository.revokeAllActiveByUserId(user.getId());
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/some-resource");
+		request.addHeader("Authorization", "");
+		request.setCookies(
+			new Cookie("accessToken", deviceATokens.accessToken()),
+			new Cookie("refreshToken", deviceATokens.refreshToken())
+		);
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain chain = new MockFilterChain();
+
+		assertThatThrownBy(() -> filter.doFilter(request, response, chain))
+			.isInstanceOf(ErrorException.class)
+			.extracting("errorCode")
+			.isEqualTo(AuthErrorCode.ACCESS_OTHER_DEVICE);
+	}
+}

--- a/backend/src/test/java/com/back/api/auth/MultiDeviceBlockRefreshTest.java
+++ b/backend/src/test/java/com/back/api/auth/MultiDeviceBlockRefreshTest.java
@@ -1,0 +1,98 @@
+package com.back.api.auth;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.api.auth.dto.JwtDto;
+import com.back.api.auth.service.AuthTokenService;
+import com.back.domain.auth.entity.ActiveSession;
+import com.back.domain.auth.repository.ActiveSessionRepository;
+import com.back.domain.auth.repository.RefreshTokenRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserRole;
+import com.back.global.error.code.AuthErrorCode;
+import com.back.global.error.exception.ErrorException;
+import com.back.global.security.CustomAuthenticationFilter;
+import com.back.support.data.TestUser;
+import com.back.support.helper.UserHelper;
+
+import jakarta.servlet.http.Cookie;
+
+@SpringBootTest(properties = {
+	"custom.jwt.access-token-duration=1",
+	"custom.jwt.refresh-token-duration=60"
+})
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+public class MultiDeviceBlockRefreshTest {
+
+	@Autowired
+	CustomAuthenticationFilter filter;
+	@Autowired
+	UserHelper userHelper;
+
+	@Autowired
+	AuthTokenService authTokenService;
+	@Autowired
+	ActiveSessionRepository activeSessionRepository;
+	@Autowired
+	RefreshTokenRepository refreshTokenRepository;
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("A의 access 만료 후 refresh 재발급 시도 중, B가 로그인(rotate)하면 ACCESS_OTHER_DEVICE 발생")
+	void refresh_blocked_by_other_device_as_access_other_device() throws Exception {
+		// given
+		TestUser testUser = userHelper.createUser(UserRole.NORMAL);
+		User user = testUser.user();
+
+		// ActiveSession 준비
+		ActiveSession session = activeSessionRepository.findByUserId(user.getId())
+			.orElseGet(() -> activeSessionRepository.save(ActiveSession.create(user)));
+
+		// 기기 A 토큰 발급
+		JwtDto deviceATokens = authTokenService.issueTokens(user, session.getSessionId(), session.getTokenVersion());
+
+		// access 만료 대기
+		Thread.sleep(1100);
+
+		// when: 기기 B 로그인 발생(rotate) + (싱글디바이스 정책이면) 기존 refresh 전부 revoke
+		session.rotate();
+		activeSessionRepository.save(session);
+		refreshTokenRepository.revokeAllActiveByUserId(user.getId());
+
+		// when: 기기 A가 만료된 access + 기존 refresh로 요청
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/some-resource");
+		request.addHeader("Authorization", ""); // (코드 수정했으면 없어도 됨)
+		request.setCookies(
+			new Cookie("accessToken", deviceATokens.accessToken()),
+			new Cookie("refreshToken", deviceATokens.refreshToken())
+		);
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain chain = new MockFilterChain();
+
+		// then
+		assertThatThrownBy(() -> filter.doFilter(request, response, chain))
+			.isInstanceOf(ErrorException.class)
+			.extracting("errorCode")
+			.isEqualTo(AuthErrorCode.ACCESS_OTHER_DEVICE);
+	}
+}

--- a/backend/src/test/java/com/back/api/auth/RefreshOneTimeUseTest.java
+++ b/backend/src/test/java/com/back/api/auth/RefreshOneTimeUseTest.java
@@ -1,0 +1,68 @@
+package com.back.api.auth;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.api.auth.dto.JwtDto;
+import com.back.api.auth.service.AuthTokenService;
+import com.back.domain.auth.entity.ActiveSession;
+import com.back.domain.auth.repository.ActiveSessionRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserRole;
+import com.back.global.error.code.AuthErrorCode;
+import com.back.global.error.exception.ErrorException;
+import com.back.support.data.TestUser;
+import com.back.support.helper.UserHelper;
+
+@SpringBootTest(properties = {
+	"custom.jwt.access-token-duration=60",
+	"custom.jwt.refresh-token-duration=60"
+})
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+class RefreshOneTimeUseTest {
+
+	@Autowired
+	UserHelper userHelper;
+	@Autowired
+	AuthTokenService authTokenService;
+	@Autowired
+	ActiveSessionRepository activeSessionRepository;
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("같은 refreshToken으로 rotate를 두 번 시도하면 두 번째는 REFRESH_TOKEN_NOT_FOUND")
+	void rotate_twice_should_fail_second_time() {
+		TestUser testUser = userHelper.createUser(UserRole.NORMAL);
+		User user = testUser.user();
+
+		ActiveSession session = activeSessionRepository.findByUserId(user.getId())
+			.orElseGet(() -> activeSessionRepository.save(ActiveSession.create(user)));
+
+		JwtDto tokens = authTokenService.issueTokens(user, session.getSessionId(), session.getTokenVersion());
+
+		// 1회차 rotate 성공
+		JwtDto rotated = authTokenService.rotateTokenByRefreshToken(tokens.refreshToken());
+		assertThat(rotated.accessToken()).isNotNull();
+
+		// 2회차 rotate 실패 (이미 revoke 처리됨)
+		assertThatThrownBy(() -> authTokenService.rotateTokenByRefreshToken(tokens.refreshToken()))
+			.isInstanceOf(ErrorException.class)
+			.extracting("errorCode")
+			.isEqualTo(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
+	}
+}

--- a/backend/src/test/java/com/back/api/auth/SessionMissingOnAccessAuthTest.java
+++ b/backend/src/test/java/com/back/api/auth/SessionMissingOnAccessAuthTest.java
@@ -1,0 +1,76 @@
+package com.back.api.auth;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.auth.repository.ActiveSessionRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserRole;
+import com.back.global.error.code.AuthErrorCode;
+import com.back.global.error.exception.ErrorException;
+import com.back.global.security.CustomAuthenticationFilter;
+import com.back.global.security.JwtProvider;
+import com.back.support.data.TestUser;
+import com.back.support.helper.UserHelper;
+
+import jakarta.servlet.http.Cookie;
+
+@SpringBootTest(properties = {
+	"custom.jwt.access-token-duration=60",
+	"custom.jwt.refresh-token-duration=60"
+})
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+class SessionMissingOnAccessAuthTest {
+
+	@Autowired
+	CustomAuthenticationFilter filter;
+	@Autowired
+	UserHelper userHelper;
+	@Autowired
+	JwtProvider jwtProvider;
+	@Autowired
+	ActiveSessionRepository activeSessionRepository;
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("ActiveSession이 없으면(access 인증 단계) UNAUTHORIZED")
+	void access_auth_fails_when_active_session_missing() throws Exception {
+		TestUser testUser = userHelper.createUser(UserRole.NORMAL);
+		User user = testUser.user();
+
+		// 세션 삭제
+		activeSessionRepository.findByUserId(user.getId()).ifPresent(activeSessionRepository::delete);
+
+		String sid = "test-sid";
+		long version = 1L;
+
+		String access = jwtProvider.generateAccessToken(user, sid, version);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/some-resource");
+		request.setCookies(new Cookie("accessToken", access));
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		assertThatThrownBy(() -> filter.doFilter(request, response, new MockFilterChain()))
+			.isInstanceOf(ErrorException.class)
+			.extracting("errorCode")
+			.isEqualTo(AuthErrorCode.UNAUTHORIZED);
+	}
+}

--- a/backend/src/test/java/com/back/api/auth/SessionMissingOnRefreshRotateTest.java
+++ b/backend/src/test/java/com/back/api/auth/SessionMissingOnRefreshRotateTest.java
@@ -1,0 +1,83 @@
+package com.back.api.auth;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.api.auth.service.AuthTokenService;
+import com.back.domain.auth.repository.ActiveSessionRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserRole;
+import com.back.global.error.code.AuthErrorCode;
+import com.back.global.error.exception.ErrorException;
+import com.back.global.security.CustomAuthenticationFilter;
+import com.back.global.security.JwtProvider;
+import com.back.support.data.TestUser;
+import com.back.support.helper.UserHelper;
+
+import jakarta.servlet.http.Cookie;
+
+@SpringBootTest(properties = {
+	"custom.jwt.access-token-duration=1",
+	"custom.jwt.refresh-token-duration=60"
+})
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+class SessionMissingOnRefreshRotateTest {
+
+	@Autowired
+	CustomAuthenticationFilter filter;
+	@Autowired
+	UserHelper userHelper;
+	@Autowired
+	AuthTokenService authTokenService;
+	@Autowired
+	ActiveSessionRepository activeSessionRepository;
+
+	@Autowired
+	JwtProvider jwtProvider;
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("ActiveSession이 없으면(refresh rotate) UNAUTHORIZED")
+	void rotate_refresh_fails_when_active_session_missing() throws Exception {
+		TestUser testUser = userHelper.createUser(UserRole.NORMAL);
+		User user = testUser.user();
+
+		activeSessionRepository.findByUserId(user.getId()).ifPresent(activeSessionRepository::delete);
+
+		String sid = "test-sid";
+		long version = 1L;
+
+		String access = jwtProvider.generateAccessToken(user, sid, version);
+		String refresh = jwtProvider.generateRefreshToken(user, sid, version);
+
+		Thread.sleep(1100); // access 만료시키기
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/some-resource");
+		request.setCookies(new Cookie("accessToken", access), new Cookie("refreshToken", refresh));
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		assertThatThrownBy(() -> filter.doFilter(request, response, new MockFilterChain()))
+			.isInstanceOf(ErrorException.class)
+			.extracting("errorCode")
+			.isEqualTo(AuthErrorCode.UNAUTHORIZED);
+	}
+}

--- a/backend/src/test/java/com/back/api/auth/TokenTypeMismatchTest.java
+++ b/backend/src/test/java/com/back/api/auth/TokenTypeMismatchTest.java
@@ -1,0 +1,53 @@
+package com.back.api.auth;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.api.auth.service.AuthTokenService;
+import com.back.domain.auth.entity.ActiveSession;
+import com.back.domain.auth.repository.ActiveSessionRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserRole;
+import com.back.global.error.code.AuthErrorCode;
+import com.back.global.error.exception.ErrorException;
+import com.back.global.security.JwtProvider;
+import com.back.support.data.TestUser;
+import com.back.support.helper.UserHelper;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class TokenTypeMismatchTest {
+
+	@Autowired
+	AuthTokenService authTokenService;
+	@Autowired
+	JwtProvider jwtProvider;
+	@Autowired
+	UserHelper userHelper;
+	@Autowired
+	ActiveSessionRepository activeSessionRepository;
+
+	@Test
+	@DisplayName("rotateTokenByRefreshToken에 accessToken을 넣으면 INVALID_TOKEN")
+	void rotate_with_access_token_should_be_invalid() {
+		TestUser testUser = userHelper.createUser(UserRole.NORMAL);
+		User user = testUser.user();
+
+		ActiveSession session = activeSessionRepository.findByUserId(user.getId())
+			.orElseGet(() -> activeSessionRepository.save(ActiveSession.create(user)));
+
+		String access = jwtProvider.generateAccessToken(user, session.getSessionId(), session.getTokenVersion());
+
+		assertThatThrownBy(() -> authTokenService.rotateTokenByRefreshToken(access))
+			.isInstanceOf(ErrorException.class)
+			.extracting("errorCode")
+			.isEqualTo(AuthErrorCode.INVALID_TOKEN);
+	}
+}


### PR DESCRIPTION
## 📌 개요
- ActiveSession 엔티티를 추가하여, 사용자의 다중 로그인을 방지

---

## ✨ 작업 내용
- ActiveSession 엔티티 추가
- 인증 / 인가 흐름
```
1. 사용자 회원가입
2. 리프레시 토큰, 액세스 토큰 생성 및 쿠키 저장
3. 세션 생성
4. RefreshToken과 ActiveSession에 tokenVersion을 저장 (tokenVersion은 동시성 처리용)
5. 사용자가 다른 기기에서 로그인
6. 세션이 존재 하는지 확인
7. 세션이 존재하는 경우, 기존의 리프레시 토큰의 revoke=true 변경하여 기존 기기 로그아웃
```

---

## 🔗 관련 이슈
- close #144   

---

## 🧪 체크리스트
- [ ] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [ ] 팀 내 코드 스타일 준수
- [ ] 이슈 연결
