### PR TITLE
[fix] QClass generated 디렉터리 checkstyle 검사 대상에서 제외, 테스트 오류 수정

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -312,6 +312,6 @@ tasks.named("clean") {
 //checkstyleMain은 compileTestJava 이후에 실행
 tasks.named<org.gradle.api.plugins.quality.Checkstyle>("checkstyleMain") {
     dependsOn(tasks.named("compileTestJava"))
-    // QueryDSL generated 폴더 제외
-    exclude("**/generated/**")
+    // QueryDSL generated 폴더 제외 (src/main/generated 기준 상대 경로)
+    exclude("com/back/**/entity/Q*.java")
 }

--- a/backend/src/test/java/com/back/api/auth/TokenTypeMismatchTest.java
+++ b/backend/src/test/java/com/back/api/auth/TokenTypeMismatchTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +15,7 @@ import com.back.domain.auth.entity.ActiveSession;
 import com.back.domain.auth.repository.ActiveSessionRepository;
 import com.back.domain.user.entity.User;
 import com.back.domain.user.entity.UserRole;
+import com.back.global.config.SecurityConfig;
 import com.back.global.error.code.AuthErrorCode;
 import com.back.global.error.exception.ErrorException;
 import com.back.global.security.JwtProvider;
@@ -24,7 +25,7 @@ import com.back.support.helper.UserHelper;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-@AutoConfigureMockMvc
+@Import(SecurityConfig.class) // UserHelper에서 PasswordEncoder 주입을 위해 필요
 class TokenTypeMismatchTest {
 
 	@Autowired


### PR DESCRIPTION
## 📌 개요
- QClass생성되는 generated 디렉터리 checkstyle 검사 대상에서 제외, 테스트 오류 수정
---

## ✨ 작업 내용
- QClass생성되는 generated 디렉터리 checkstyle 검사 대상에서 제외, 테스트 오류 수정
- QClass checkstyle 검사 대상에서 제외 이유: ./gradlew clean build 시에 로그 QClass에 대해 checkstyle로그 수백줄 발생
<img width="1762" height="1203" alt="image" src="https://github.com/user-attachments/assets/e5cb7b3b-c63a-4624-827e-122cef9fb940" />

- 테스트 수정 사유: 기존 TokenTypeMismatchTest.java에서 사용하는 UserHelper가 passwordEncoder를 필요로함, 명시적으로 주입

---

## 🔗 관련 이슈
- close #179 

---

## 🧪 체크리스트
- [ ] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [ ] 팀 내 코드 스타일 준수
- [ ] 이슈 연결
