### PR TITLE
[fix] 엔티티 ID @GeneratedValue 누락 부분 추가

### DIFF
--- a/backend/src/main/java/com/back/domain/auth/entity/ActiveSession.java
+++ b/backend/src/main/java/com/back/domain/auth/entity/ActiveSession.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
@@ -36,7 +37,7 @@ import lombok.NoArgsConstructor;
 public class ActiveSession extends BaseEntity {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@OneToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/back/domain/auth/entity/RefreshToken.java
+++ b/backend/src/main/java/com/back/domain/auth/entity/RefreshToken.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
@@ -33,7 +34,7 @@ import lombok.NoArgsConstructor;
 public class RefreshToken extends BaseEntity {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 📌 개요
- @GeneratedValue에 strategy를 안 쓰면 Hibernate가 SEQUENCE 전략을 기본으로 선택하고, 테이블 명 기반으로 시퀀스 이름을 추론하므로 해당 부분에서 오류 발생.
- 누락된 부분 추가 작업 진행함

---

## ✨ 작업 내용
- Auth 도메인 추가 작성

---

## 🔗 관련 이슈
- close #183

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
