### PR TITLE
[perf] 내 티켓 조회 성능 개선 - dto projection 방법으로 변경

### DIFF
--- a/backend/src/main/java/com/back/api/ticket/controller/TicketController.java
+++ b/backend/src/main/java/com/back/api/ticket/controller/TicketController.java
@@ -28,12 +28,9 @@ public class TicketController implements TicketApi {
 	public ApiResponse<List<TicketResponse>> getMyTickets() {
 		Long userId = httpRequestContext.getUser().getId();
 
-		List<Ticket> tickets = ticketService.getMyTickets(userId);
+		List<TicketResponse> responses = ticketService.getMyTickets(userId);
 
-		return ApiResponse.ok(
-			"사용자의 티켓 목록 조회 성공",
-			tickets.stream().map(TicketResponse::from).toList()
-		);
+		return ApiResponse.ok("사용자의 티켓 목록 조회 성공", responses);
 	}
 
 	@Override

--- a/backend/src/main/java/com/back/api/ticket/dto/response/TicketResponse.java
+++ b/backend/src/main/java/com/back/api/ticket/dto/response/TicketResponse.java
@@ -2,7 +2,10 @@ package com.back.api.ticket.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.back.domain.seat.entity.SeatGrade;
+import com.back.domain.seat.entity.SeatStatus;
 import com.back.domain.ticket.entity.Ticket;
+import com.back.domain.ticket.entity.TicketStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -37,6 +40,32 @@ public record TicketResponse(
 	@Schema(description = "사용 시간", example = "2024-01-01T18:00:00")
 	LocalDateTime usedAt
 ) {
+	public TicketResponse(
+		Long ticketId,
+		Long eventId,
+		String eventTitle,
+		String seatCode,
+		SeatGrade seatGrade,
+		Integer seatPrice,
+		SeatStatus seatStatus,
+		TicketStatus ticketStatus,
+		LocalDateTime issuedAt,
+		LocalDateTime usedAt
+	) {
+		this(
+			ticketId,
+			eventId,
+			eventTitle,
+			seatCode,
+			seatGrade != null ? seatGrade.getDisplayName() : null,
+			seatPrice != null ? seatPrice : 0,
+			seatStatus != null ? seatStatus.name() : null,
+			ticketStatus.name(),
+			issuedAt,
+			usedAt
+		);
+	}
+
 	public static TicketResponse from(Ticket ticket) {
 		return new TicketResponse(
 			ticket.getId(),

--- a/backend/src/main/java/com/back/api/ticket/service/TicketService.java
+++ b/backend/src/main/java/com/back/api/ticket/service/TicketService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.back.api.seat.service.SeatService;
+import com.back.api.ticket.dto.response.TicketResponse;
 import com.back.domain.event.entity.Event;
 import com.back.domain.event.repository.EventRepository;
 import com.back.domain.seat.entity.Seat;
@@ -165,8 +166,8 @@ public class TicketService {
 	 * 내 티켓 목록 조회
 	 */
 	@Transactional(readOnly = true)
-	public List<Ticket> getMyTickets(Long userId) {
-		return ticketRepository.findByOwnerId(userId);
+	public List<TicketResponse> getMyTickets(Long userId) {
+		return ticketRepository.findMyTicketDto(userId);
 	}
 
 	/**

--- a/backend/src/main/java/com/back/domain/ticket/repository/TicketRepository.java
+++ b/backend/src/main/java/com/back/domain/ticket/repository/TicketRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import com.back.domain.ticket.entity.Ticket;
 import com.back.domain.ticket.entity.TicketStatus;
 
-public interface TicketRepository extends JpaRepository<Ticket, Long> {
+public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketRepositoryCustom {
 
 	List<Ticket> findByOwnerId(Long userId);
 

--- a/backend/src/main/java/com/back/domain/ticket/repository/TicketRepositoryCustom.java
+++ b/backend/src/main/java/com/back/domain/ticket/repository/TicketRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.back.domain.ticket.repository;
+
+import java.util.List;
+
+import com.back.api.ticket.dto.response.TicketResponse;
+
+public interface TicketRepositoryCustom {
+
+	List<TicketResponse> findMyTicketDto(Long userId);
+
+}

--- a/backend/src/main/java/com/back/domain/ticket/repository/TicketRepositoryImpl.java
+++ b/backend/src/main/java/com/back/domain/ticket/repository/TicketRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.back.domain.ticket.repository;
+
+import static com.back.domain.event.entity.QEvent.*;
+import static com.back.domain.seat.entity.QSeat.*;
+import static com.back.domain.ticket.entity.QTicket.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.back.api.ticket.dto.response.TicketResponse;
+import com.back.domain.ticket.entity.TicketStatus;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class TicketRepositoryImpl implements TicketRepositoryCustom {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<TicketResponse> findMyTicketDto(Long userId) {
+		return jpaQueryFactory
+			.select(Projections.constructor(
+				TicketResponse.class,
+				ticket.id,
+				event.id,
+				event.title,
+				seat.seatCode,
+				seat.grade,
+				seat.price,
+				seat.seatStatus,
+				ticket.ticketStatus,
+				ticket.issuedAt,
+				ticket.usedAt
+			))
+			.from(ticket)
+			.join(ticket.event, event)
+			.leftJoin(ticket.seat, seat)
+			.where(
+				ticket.owner.id.eq(userId),
+				ticket.ticketStatus.in(
+					TicketStatus.PAID,
+					TicketStatus.ISSUED,
+					TicketStatus.USED
+				)
+			)
+			.orderBy(ticket.createAt.desc())
+			.fetch();
+
+	}
+}

--- a/backend/src/test/java/com/back/api/ticket/service/TicketServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/api/ticket/service/TicketServiceIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.back.api.ticket.dto.response.TicketResponse;
 import com.back.domain.event.entity.Event;
 import com.back.domain.event.repository.EventRepository;
 import com.back.domain.seat.entity.Seat;
@@ -180,7 +181,7 @@ class TicketServiceIntegrationTest {
 		ticketHelper.createIssuedTicket(user, seat, event);
 		ticketHelper.createIssuedTicket(user, seat2, event);
 
-		List<Ticket> myTickets = ticketService.getMyTickets(user.getId());
+		List<TicketResponse> myTickets = ticketService.getMyTickets(user.getId());
 
 		assertThat(myTickets).hasSize(2);
 	}


### PR DESCRIPTION
## 📌 개요
- 기존 내 티켓 조회 API에서는 N+1 문제 발생
- QueryDSL DTO Projection 방법으로 쿼리 3개 -> 1개로 줄임

---

## ✨ 작업 내용
- TicketRepositoryCustom, TicketRepositoryImpl 생성
- findMyTicketDto 를 통한 내 티켓 조회
<img width="340" height="118" alt="image" src="https://github.com/user-attachments/assets/1a623a6d-7ade-4829-a1cd-1ba86fedade6" />

---

## 🔗 관련 이슈
- close #159

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
