### PR TITLE
[refactor] preRegister 내 사전등록 조회 응답값 수정 및 Event 엔티티 eventDate 추가

### DIFF
--- a/backend/src/main/java/com/back/api/event/dto/request/EventCreateRequest.java
+++ b/backend/src/main/java/com/back/api/event/dto/request/EventCreateRequest.java
@@ -57,6 +57,10 @@ public record EventCreateRequest(
 	@NotNull(message = "티켓팅 종료일은 필수입니다.")
 	LocalDateTime ticketCloseAt,
 
+	@Schema(description = "이벤트 날짜", example = "2026-02-28T19:00:00")
+	@NotNull(message = "이벤트 날짜는 필수입니다.")
+	LocalDateTime eventDate,
+
 	@Schema(description = "최대 티켓 수량", example = "5000")
 	@NotNull(message = "최대 티켓 수량은 필수입니다.")
 	@Min(value = 1, message = "최대 티켓 수량은 1 이상이어야 합니다.")
@@ -75,6 +79,7 @@ public record EventCreateRequest(
 			.preCloseAt(preCloseAt)
 			.ticketOpenAt(ticketOpenAt)
 			.ticketCloseAt(ticketCloseAt)
+			.eventDate(eventDate)
 			.maxTicketAmount(maxTicketAmount)
 			.status(EventStatus.READY)
 			.build();

--- a/backend/src/main/java/com/back/api/event/dto/request/EventUpdateRequest.java
+++ b/backend/src/main/java/com/back/api/event/dto/request/EventUpdateRequest.java
@@ -56,6 +56,10 @@ public record EventUpdateRequest(
 	@NotNull(message = "티켓팅 종료일은 필수입니다.")
 	LocalDateTime ticketCloseAt,
 
+	@Schema(description = "이벤트 날짜 (실제 이벤트 개최일)", example = "2026-02-15T19:00:00")
+	@NotNull(message = "이벤트 날짜는 필수입니다.")
+	LocalDateTime eventDate,
+
 	@Schema(description = "최대 티켓 수량", example = "5000")
 	@NotNull(message = "최대 티켓 수량은 필수입니다.")
 	@Min(value = 1, message = "최대 티켓 수량은 1 이상이어야 합니다.")

--- a/backend/src/main/java/com/back/api/event/dto/response/EventListResponse.java
+++ b/backend/src/main/java/com/back/api/event/dto/response/EventListResponse.java
@@ -43,6 +43,9 @@ public record EventListResponse(
 	@Schema(description = "티켓팅 종료일시", example = "2026-01-30T23:59:59")
 	LocalDateTime ticketCloseAt,
 
+	@Schema(description = "이벤트 날짜 (실제 이벤트 개최일)", example = "2026-02-15T19:00:00")
+	LocalDateTime eventDate,
+
 	@Schema(description = "이벤트 상태 (READY: 준비중, PRE_OPEN: 사전등록중, QUEUE_READY: 대기열 준비, OPEN: 티켓팅 진행중, CLOSED: 마감)",
 		example = "PRE_OPEN")
 	EventStatus status,
@@ -63,6 +66,7 @@ public record EventListResponse(
 			event.getPreCloseAt(),
 			event.getTicketOpenAt(),
 			event.getTicketCloseAt(),
+			event.getEventDate(),
 			event.getStatus(),
 			event.getCreateAt()
 		);

--- a/backend/src/main/java/com/back/api/event/dto/response/EventResponse.java
+++ b/backend/src/main/java/com/back/api/event/dto/response/EventResponse.java
@@ -46,6 +46,9 @@ public record EventResponse(
 	@Schema(description = "티켓팅 종료일시", example = "2026-01-30T23:59:59")
 	LocalDateTime ticketCloseAt,
 
+	@Schema(description = "이벤트 날짜 (실제 이벤트 개최일)", example = "2026-02-15T19:00:00")
+	LocalDateTime eventDate,
+
 	@Schema(description = "최대 티켓 수량", example = "5000")
 	Integer maxTicketAmount,
 
@@ -67,6 +70,7 @@ public record EventResponse(
 			event.getPreCloseAt(),
 			event.getTicketOpenAt(),
 			event.getTicketCloseAt(),
+			event.getEventDate(),
 			event.getMaxTicketAmount(),
 			event.getStatus()
 		);

--- a/backend/src/main/java/com/back/api/event/service/EventService.java
+++ b/backend/src/main/java/com/back/api/event/service/EventService.java
@@ -64,7 +64,8 @@ public class EventService {
 			request.preOpenAt(),
 			request.preCloseAt(),
 			request.ticketOpenAt(),
-			request.ticketCloseAt()
+			request.ticketCloseAt(),
+			request.eventDate()
 		);
 		event.changeStatus(request.status());
 

--- a/backend/src/main/java/com/back/api/preregister/dto/response/PreRegisterResponse.java
+++ b/backend/src/main/java/com/back/api/preregister/dto/response/PreRegisterResponse.java
@@ -2,6 +2,7 @@ package com.back.api.preregister.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.back.domain.event.entity.Event;
 import com.back.domain.preregister.entity.PreRegister;
 import com.back.domain.preregister.entity.PreRegisterStatus;
 
@@ -13,26 +14,47 @@ public record PreRegisterResponse(
 	@Schema(description = "사전등록 ID", example = "1")
 	Long id,
 
-	@Schema(description = "이벤트 ID", example = "1")
-	Long eventId,
-
 	@Schema(description = "사용자 ID", example = "1")
 	Long userId,
+
+	@Schema(description = "이벤트 ID", example = "1")
+	Long eventId,
 
 	@Schema(description = "사전등록 상태", example = "REGISTERED")
 	PreRegisterStatus status,
 
 	@Schema(description = "등록일시", example = "2025-12-10T10:00:00")
-	LocalDateTime createdAt
+	LocalDateTime createdAt,
+
+	@Schema(description = "이벤트 이미지 URL", example = "https://example.com/image.jpg")
+	String imageUrl,
+
+	@Schema(description = "이벤트 제목", example = "아이유 콘서트")
+	String eventTitle,
+
+	@Schema(description = "이벤트 날짜", example = "2025-03-15T19:00:00")
+	LocalDateTime eventDate,
+
+	@Schema(description = "이벤트 장소", example = "잠실 올림픽 주경기장")
+	String place,
+
+	@Schema(description = "티켓 오픈 날짜", example = "2025-02-20T10:00:00")
+	LocalDateTime ticketOpenAt
 ) {
 
 	public static PreRegisterResponse from(PreRegister preRegister) {
+		Event event = preRegister.getEvent();
 		return new PreRegisterResponse(
 			preRegister.getId(),
-			preRegister.getEventId(),
 			preRegister.getUserId(),
+			preRegister.getEventId(),
 			preRegister.getPreRegisterStatus(),
-			preRegister.getCreateAt()
+			preRegister.getCreateAt(),
+			event.getImageUrl(),
+			event.getTitle(),
+			event.getEventDate(),
+			event.getPlace(),
+			event.getTicketOpenAt()
 		);
 	}
 }

--- a/backend/src/main/java/com/back/domain/event/entity/Event.java
+++ b/backend/src/main/java/com/back/domain/event/entity/Event.java
@@ -62,6 +62,9 @@ public class Event extends BaseEntity {
 	private LocalDateTime ticketCloseAt;
 
 	@Column(nullable = false)
+	private LocalDateTime eventDate;
+
+	@Column(nullable = false)
 	private Integer maxTicketAmount;
 
 	@Enumerated(EnumType.STRING)
@@ -76,7 +79,7 @@ public class Event extends BaseEntity {
 		String imageUrl, Integer minPrice, Integer maxPrice,
 		LocalDateTime preOpenAt, LocalDateTime preCloseAt,
 		LocalDateTime ticketOpenAt, LocalDateTime ticketCloseAt,
-		Integer maxTicketAmount, EventStatus status) {
+		LocalDateTime eventDate, Integer maxTicketAmount, EventStatus status) {
 		validatePrice(minPrice, maxPrice);
 		this.title = title;
 		this.category = category;
@@ -89,6 +92,7 @@ public class Event extends BaseEntity {
 		this.preCloseAt = preCloseAt;
 		this.ticketOpenAt = ticketOpenAt;
 		this.ticketCloseAt = ticketCloseAt;
+		this.eventDate = eventDate;
 		this.maxTicketAmount = maxTicketAmount;
 		this.status = status != null ? status : EventStatus.READY;
 		this.deleted = false;
@@ -111,11 +115,12 @@ public class Event extends BaseEntity {
 	}
 
 	public void changePeriod(LocalDateTime preOpenAt, LocalDateTime preCloseAt,
-		LocalDateTime ticketOpenAt, LocalDateTime ticketCloseAt) {
+		LocalDateTime ticketOpenAt, LocalDateTime ticketCloseAt, LocalDateTime eventDate) {
 		this.preOpenAt = preOpenAt;
 		this.preCloseAt = preCloseAt;
 		this.ticketOpenAt = ticketOpenAt;
 		this.ticketCloseAt = ticketCloseAt;
+		this.eventDate = eventDate;
 	}
 
 	public void changeStatus(EventStatus status) {

--- a/backend/src/main/java/com/back/global/init/EventDataInit.java
+++ b/backend/src/main/java/com/back/global/init/EventDataInit.java
@@ -48,6 +48,7 @@ public class EventDataInit implements ApplicationRunner {
 			.preCloseAt(now.plusDays(7))
 			.ticketOpenAt(now.plusDays(10))
 			.ticketCloseAt(now.plusDays(30))
+			.eventDate(now.plusDays(40))
 			.maxTicketAmount(5000)
 			.status(EventStatus.PRE_OPEN)
 			.build();
@@ -64,6 +65,7 @@ public class EventDataInit implements ApplicationRunner {
 			.preCloseAt(now.plusDays(3))
 			.ticketOpenAt(now.plusDays(5))
 			.ticketCloseAt(now.plusDays(7))
+			.eventDate(now.plusDays(10))
 			.maxTicketAmount(500)
 			.status(EventStatus.READY)
 			.build();
@@ -80,10 +82,10 @@ public class EventDataInit implements ApplicationRunner {
 			.preCloseAt(now.minusDays(8))
 			.ticketOpenAt(now.minusDays(5))
 			.ticketCloseAt(now.plusDays(14))
+			.eventDate(now.plusDays(21))
 			.maxTicketAmount(3000)
 			.status(EventStatus.PRE_OPEN)
 			.build();
-
 
 		Event event4 = Event.builder()
 			.title("2025 스프링 재즈 나이트")
@@ -97,6 +99,7 @@ public class EventDataInit implements ApplicationRunner {
 			.preCloseAt(now.minusDays(8))
 			.ticketOpenAt(now.plusHours(1).plusMinutes(5))
 			.ticketCloseAt(now.plusDays(14))
+			.eventDate(now.plusDays(21))
 			.maxTicketAmount(3000)
 			.status(EventStatus.PRE_OPEN)
 			.build();

--- a/backend/src/main/java/com/back/global/init/perf/PerfEventDataInitializer.java
+++ b/backend/src/main/java/com/back/global/init/perf/PerfEventDataInitializer.java
@@ -48,6 +48,7 @@ public class PerfEventDataInitializer {
 			.preCloseAt(now.plusDays(5))
 			.ticketOpenAt(now.plusDays(7))
 			.ticketCloseAt(now.plusDays(30))
+			.eventDate(now.plusDays(35))
 			.maxTicketAmount(500)
 			.status(EventStatus.PRE_OPEN)
 			.build());
@@ -65,6 +66,7 @@ public class PerfEventDataInitializer {
 			.preCloseAt(now.minusDays(3))
 			.ticketOpenAt(now.plusMinutes(30))
 			.ticketCloseAt(now.plusDays(20))
+			.eventDate(now.plusDays(25))
 			.maxTicketAmount(500)
 			.status(EventStatus.QUEUE_READY)
 			.build());
@@ -82,6 +84,7 @@ public class PerfEventDataInitializer {
 			.preCloseAt(now.minusDays(2))
 			.ticketOpenAt(now.minusHours(1))
 			.ticketCloseAt(now.plusDays(3))
+			.eventDate(now.plusDays(8))
 			.maxTicketAmount(500)
 			.status(EventStatus.OPEN)
 			.build());
@@ -100,6 +103,7 @@ public class PerfEventDataInitializer {
 				.preCloseAt(now.minusDays(20))
 				.ticketOpenAt(now.minusDays(15))
 				.ticketCloseAt(now.minusDays(10))
+				.eventDate(now.minusDays(5))
 				.maxTicketAmount(500)
 				.status(EventStatus.CLOSED)
 				.build());
@@ -138,6 +142,7 @@ public class PerfEventDataInitializer {
 			.preCloseAt(baseTime.plusDays(9))
 			.ticketOpenAt(baseTime.plusDays(12))
 			.ticketCloseAt(baseTime.plusDays(30))
+			.eventDate(baseTime.plusDays(35))
 			.maxTicketAmount(maxTickets)
 			.status(EventStatus.READY)
 			.build();
@@ -157,6 +162,7 @@ public class PerfEventDataInitializer {
 			.preCloseAt(baseTime.plusDays(5))
 			.ticketOpenAt(baseTime.plusDays(7))
 			.ticketCloseAt(baseTime.plusDays(21))
+			.eventDate(baseTime.plusDays(25))
 			.maxTicketAmount(maxTickets)
 			.status(EventStatus.READY)
 			.build();
@@ -176,6 +182,7 @@ public class PerfEventDataInitializer {
 			.preCloseAt(baseTime.plusDays(3))
 			.ticketOpenAt(baseTime.plusDays(5))
 			.ticketCloseAt(baseTime.plusDays(10))
+			.eventDate(baseTime.plusDays(12))
 			.maxTicketAmount(maxTickets)
 			.status(EventStatus.READY)
 			.build();

--- a/backend/src/test/java/com/back/api/event/controller/AdminEventControllerTest.java
+++ b/backend/src/test/java/com/back/api/event/controller/AdminEventControllerTest.java
@@ -52,6 +52,7 @@ class AdminEventControllerTest {
 	private LocalDateTime preCloseAt;
 	private LocalDateTime ticketOpenAt;
 	private LocalDateTime ticketCloseAt;
+	private LocalDateTime eventDate;
 
 	@BeforeEach
 	void setUp() {
@@ -61,6 +62,7 @@ class AdminEventControllerTest {
 		preCloseAt = now.plusDays(5);
 		ticketOpenAt = now.plusDays(6);
 		ticketCloseAt = now.plusDays(10);
+		eventDate = now.plusDays(15);
 	}
 
 	@Nested
@@ -83,6 +85,7 @@ class AdminEventControllerTest {
 				preCloseAt,
 				ticketOpenAt,
 				ticketCloseAt,
+				eventDate,
 				100
 			);
 
@@ -113,7 +116,7 @@ class AdminEventControllerTest {
 				"",
 				EventCategory.CONCERT,
 				"설명", "장소", "url", 1000, 2000,
-				preOpenAt, preCloseAt, ticketOpenAt, ticketCloseAt, 100
+				preOpenAt, preCloseAt, ticketOpenAt, ticketCloseAt, eventDate, 100
 			);
 
 			// when & then
@@ -134,6 +137,7 @@ class AdminEventControllerTest {
 				preOpenAt, preCloseAt,
 				ticketCloseAt.plusDays(1),
 				ticketCloseAt,
+				eventDate,
 				100
 			);
 
@@ -170,6 +174,7 @@ class AdminEventControllerTest {
 				preCloseAt,
 				ticketOpenAt,
 				ticketCloseAt,
+				now.plusDays(35),
 				200,
 				EventStatus.PRE_OPEN
 			);
@@ -197,7 +202,7 @@ class AdminEventControllerTest {
 			EventUpdateRequest request = new EventUpdateRequest(
 				"수정", EventCategory.CONCERT, "설명", "장소", "url",
 				1000, 2000, preOpenAt, preCloseAt, ticketOpenAt, ticketCloseAt,
-				100, EventStatus.READY
+				now.plusDays(35), 100, EventStatus.READY
 			);
 
 			// when & then

--- a/backend/src/test/java/com/back/api/event/service/EventServiceTest.java
+++ b/backend/src/test/java/com/back/api/event/service/EventServiceTest.java
@@ -45,6 +45,7 @@ class EventServiceTest {
 	private LocalDateTime preCloseAt;
 	private LocalDateTime ticketOpenAt;
 	private LocalDateTime ticketCloseAt;
+	private LocalDateTime eventDate;
 
 	@BeforeEach
 	void setUp() {
@@ -54,6 +55,7 @@ class EventServiceTest {
 		preCloseAt = now.plusDays(5);
 		ticketOpenAt = now.plusDays(6);
 		ticketCloseAt = now.plusDays(10);
+		eventDate = now.plusDays(15);
 	}
 
 	@Nested
@@ -76,6 +78,7 @@ class EventServiceTest {
 				preCloseAt,
 				ticketOpenAt,
 				ticketCloseAt,
+				eventDate,
 				100
 			);
 
@@ -109,6 +112,7 @@ class EventServiceTest {
 				preOpenAt,
 				ticketOpenAt,
 				ticketCloseAt,
+				eventDate,
 				100
 			);
 
@@ -134,6 +138,7 @@ class EventServiceTest {
 				preCloseAt,
 				ticketCloseAt,
 				ticketOpenAt,
+				eventDate,
 				100
 			);
 
@@ -159,6 +164,7 @@ class EventServiceTest {
 				ticketOpenAt.plusDays(1),
 				ticketOpenAt,
 				ticketCloseAt,
+				eventDate,
 				100
 			);
 
@@ -199,6 +205,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt)
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -215,6 +222,7 @@ class EventServiceTest {
 				preCloseAt,
 				ticketOpenAt,
 				ticketCloseAt,
+			now.plusDays(35),
 				200,
 				EventStatus.PRE_OPEN
 			);
@@ -249,6 +257,7 @@ class EventServiceTest {
 				preCloseAt,
 				ticketOpenAt,
 				ticketCloseAt,
+			now.plusDays(35),
 				200,
 				EventStatus.PRE_OPEN
 			);
@@ -276,6 +285,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt)
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -293,6 +303,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt.plusDays(1))
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -310,6 +321,7 @@ class EventServiceTest {
 				preCloseAt,
 				ticketOpenAt, // 첫 번째 이벤트와 동일한 ticketOpenAt
 				ticketCloseAt,
+			now.plusDays(35),
 				200,
 				EventStatus.PRE_OPEN
 			);
@@ -336,6 +348,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt)
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -353,6 +366,7 @@ class EventServiceTest {
 				preCloseAt,
 				ticketOpenAt, // 동일한 ticketOpenAt
 				ticketCloseAt,
+			now.plusDays(35),
 				200,
 				EventStatus.PRE_OPEN
 			);
@@ -387,6 +401,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt)
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -434,6 +449,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt)
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -479,6 +495,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt)
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -495,6 +512,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt)
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.PRE_OPEN)
 				.build());
@@ -524,6 +542,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt)
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.PRE_OPEN)
 				.build());
@@ -554,6 +573,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt)
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -584,6 +604,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt)
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.PRE_OPEN)
 				.build());
@@ -623,6 +644,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt)
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -669,6 +691,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt)
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -685,6 +708,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt.plusDays(1))
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -701,6 +725,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(ticketOpenAt.plusDays(2))
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.PRE_OPEN)
 				.build());
@@ -749,6 +774,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(now.plusDays(7)) // 범위 내
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -765,6 +791,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(now.plusDays(10)) // 범위 내
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());
@@ -782,6 +809,7 @@ class EventServiceTest {
 				.preCloseAt(preCloseAt)
 				.ticketOpenAt(now.plusDays(20)) // 범위 밖
 				.ticketCloseAt(ticketCloseAt)
+			.eventDate(now.plusDays(35))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build());

--- a/backend/src/test/java/com/back/api/notification/listener/NotificationEventListenerTest.java
+++ b/backend/src/test/java/com/back/api/notification/listener/NotificationEventListenerTest.java
@@ -98,6 +98,7 @@ class NotificationEventListenerTest {
 			.preCloseAt(java.time.LocalDateTime.now().plusDays(3))
 			.ticketOpenAt(java.time.LocalDateTime.now().plusDays(5))
 			.ticketCloseAt(java.time.LocalDateTime.now().plusDays(7))
+			.eventDate(java.time.LocalDateTime.now().plusDays(10))
 			.maxTicketAmount(1000)
 			.status(EventStatus.READY)
 			.build());

--- a/backend/src/test/java/com/back/api/preregister/service/PreRegisterServiceTest.java
+++ b/backend/src/test/java/com/back/api/preregister/service/PreRegisterServiceTest.java
@@ -108,7 +108,6 @@ class PreRegisterServiceTest {
 			assertThat(response.id()).isNotNull();
 			assertThat(response.eventId()).isEqualTo(testEvent.getId());
 			assertThat(response.userId()).isEqualTo(testUser.user().getId());
-			assertThat(response.status()).isEqualTo(PreRegisterStatus.REGISTERED);
 
 			// DB 검증
 			PreRegister savedPreRegister = preRegisterRepository
@@ -214,6 +213,7 @@ class PreRegisterServiceTest {
 				.preCloseAt(now.plusDays(5))
 				.ticketOpenAt(now.plusDays(10))
 				.ticketCloseAt(now.plusDays(20))
+				.eventDate(now.plusDays(25))
 				.maxTicketAmount(100)
 				.status(EventStatus.READY)
 				.build();
@@ -249,6 +249,7 @@ class PreRegisterServiceTest {
 				.preCloseAt(now.minusDays(8))  // 8일 전에 종료
 				.ticketOpenAt(now.minusDays(5))
 				.ticketCloseAt(now.plusDays(10))
+				.eventDate(now.plusDays(15))
 				.maxTicketAmount(100)
 				.status(EventStatus.OPEN)
 				.build();
@@ -508,7 +509,6 @@ class PreRegisterServiceTest {
 			assertThat(response.id()).isNotNull();
 			assertThat(response.eventId()).isEqualTo(testEvent.getId());
 			assertThat(response.userId()).isEqualTo(testUser.user().getId());
-			assertThat(response.status()).isEqualTo(PreRegisterStatus.REGISTERED);
 			assertThat(response.createdAt()).isNotNull();
 		}
 
@@ -645,8 +645,7 @@ class PreRegisterServiceTest {
 				testUser.user().getId(),
 				request
 			);
-			assertThat(registerResponse.status()).isEqualTo(PreRegisterStatus.REGISTERED);
-
+	
 			// 2. 조회
 			PreRegisterResponse getResponse = preRegisterService.getMyPreRegister(
 				testEvent.getId(),
@@ -756,8 +755,7 @@ class PreRegisterServiceTest {
 				testUser.user().getId(),
 				request
 			);
-			assertThat(registerResponse.status()).isEqualTo(PreRegisterStatus.REGISTERED);
-
+	
 			// when: 취소
 			preRegisterService.cancel(testEvent.getId(), testUser.user().getId());
 
@@ -773,7 +771,6 @@ class PreRegisterServiceTest {
 			);
 
 			// then: 재등록 성공 및 기존 레코드를 재활용
-			assertThat(reRegisterResponse.status()).isEqualTo(PreRegisterStatus.REGISTERED);
 			assertThat(reRegisterResponse.id()).isEqualTo(registerResponse.id()); // 같은 레코드 재활용
 			assertThat(preRegisterService.isRegistered(testEvent.getId(), testUser.user().getId())).isTrue();
 

--- a/backend/src/test/java/com/back/api/seat/service/SeatServiceUnitTest.java
+++ b/backend/src/test/java/com/back/api/seat/service/SeatServiceUnitTest.java
@@ -83,6 +83,7 @@ class SeatServiceUnitTest {
 			.preCloseAt(LocalDateTime.now().plusDays(2))
 			.ticketOpenAt(LocalDateTime.now().plusDays(3))
 			.ticketCloseAt(LocalDateTime.now().plusDays(4))
+			.eventDate(LocalDateTime.now().plusDays(10))
 			.maxTicketAmount(100)
 			.status(EventStatus.READY)
 			.build();

--- a/backend/src/test/java/com/back/support/factory/EventFactory.java
+++ b/backend/src/test/java/com/back/support/factory/EventFactory.java
@@ -24,6 +24,7 @@ public class EventFactory extends BaseFactory {
 			.preCloseAt(LocalDateTime.now().minusDays(5))
 			.ticketOpenAt(LocalDateTime.now().minusDays(3))
 			.ticketCloseAt(LocalDateTime.now().plusDays(30))
+			.eventDate(LocalDateTime.now().plusDays(35))
 			.maxTicketAmount(faker.number().numberBetween(1000, 10000))
 			.status(EventStatus.OPEN)
 			.build();
@@ -45,6 +46,7 @@ public class EventFactory extends BaseFactory {
 			.preCloseAt(LocalDateTime.now().minusDays(5))
 			.ticketOpenAt(LocalDateTime.now().minusDays(3))
 			.ticketCloseAt(LocalDateTime.now().plusDays(30))
+			.eventDate(LocalDateTime.now().plusDays(35))
 			.maxTicketAmount(faker.number().numberBetween(1000, 10000))
 			.status(EventStatus.OPEN)
 			.build();
@@ -66,6 +68,7 @@ public class EventFactory extends BaseFactory {
 			.preCloseAt(LocalDateTime.now().minusDays(5))
 			.ticketOpenAt(LocalDateTime.now().minusDays(3))
 			.ticketCloseAt(LocalDateTime.now().plusDays(30))
+			.eventDate(LocalDateTime.now().plusDays(35))
 			.maxTicketAmount(faker.number().numberBetween(1000, 10000))
 			.status(status)
 			.build();
@@ -87,6 +90,7 @@ public class EventFactory extends BaseFactory {
 			.preCloseAt(LocalDateTime.now().plusDays(7))
 			.ticketOpenAt(LocalDateTime.now().plusDays(10))
 			.ticketCloseAt(LocalDateTime.now().plusDays(30))
+			.eventDate(LocalDateTime.now().plusDays(35))
 			.maxTicketAmount(faker.number().numberBetween(1000, 10000))
 			.status(EventStatus.PRE_OPEN)
 			.build();
@@ -108,6 +112,7 @@ public class EventFactory extends BaseFactory {
 			.preCloseAt(LocalDateTime.now().plusDays(10))
 			.ticketOpenAt(LocalDateTime.now().plusDays(15))
 			.ticketCloseAt(LocalDateTime.now().plusDays(30))
+			.eventDate(LocalDateTime.now().plusDays(35))
 			.maxTicketAmount(faker.number().numberBetween(1000, 10000))
 			.status(EventStatus.READY)
 			.build();
@@ -129,6 +134,7 @@ public class EventFactory extends BaseFactory {
 			.preCloseAt(LocalDateTime.now().minusDays(8))
 			.ticketOpenAt(LocalDateTime.now().minusDays(5))
 			.ticketCloseAt(LocalDateTime.now().plusDays(10))
+			.eventDate(LocalDateTime.now().plusDays(15))
 			.maxTicketAmount(faker.number().numberBetween(1000, 10000))
 			.status(EventStatus.OPEN)
 			.build();


### PR DESCRIPTION
## 📌 개요
-  preRegister 내 사전등록 조회 응답값 수정 및 Event 엔티티 eventDate 추가

---

## ✨ 작업 내용
- preRegister 내 사전등록 조회 응답값 수정
- Event 엔티티에서 이벤트 날짜 (실제 이벤트 개최일) 누락으로 추가 및 관련 코드 수정 진행

---

## 🔗 관련 이슈
- close #193 

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
