### PR TITLE
fix: DraftTicketExpirationScheduler prod 환경에서 임시 비활성화 처리

### DIFF
--- a/backend/src/main/java/com/back/api/ticket/scheduler/DraftTicketExpirationScheduler.java
+++ b/backend/src/main/java/com/back/api/ticket/scheduler/DraftTicketExpirationScheduler.java
@@ -3,6 +3,7 @@ package com.back.api.ticket.scheduler;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@Profile({"perf"})
 public class DraftTicketExpirationScheduler {
 
 	private static final int PAGE_SIZE = 500;


### PR DESCRIPTION
## 📌 개요
- fix: DraftTicketExpirationScheduler prod 환경에서 임시 비활성화 처리

---

## ✨ 작업 내용
- fix: DraftTicketExpirationScheduler prod 환경에서 임시 비활성화 처리

---

## 🔗 관련 이슈
- close #202 

---

## 🧪 체크리스트
- [ ] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [ ] 팀 내 코드 스타일 준수
- [ ] 이슈 연결
