### PR TITLE
[feat] 대기열 도메인 나를 포함한 상위 인원 모두 입장처리하는 API 추가(테스트용)

### DIFF
--- a/backend/src/main/java/com/back/api/queue/controller/QueueEntryApi.java
+++ b/backend/src/main/java/com/back/api/queue/controller/QueueEntryApi.java
@@ -75,4 +75,18 @@ public interface QueueEntryApi {
 		@Parameter(description = "이벤트 ID", example = "1")
 		@PathVariable Long eventId
 	);
+
+	@Operation(
+		summary = "[테스트용] 나를 포함한 앞 사용자 모두 입장 처리",
+		description = "나를 포함하여 내 앞에 있는 모든 사용자들을 입장 처리합니다."
+	)
+	@ApiErrorCode({
+		"NOT_FOUND_QUEUE_ENTRY",
+		"NOT_WAITING_STATUS",
+		"NOT_INVALID_COUNT"
+	})
+	ApiResponse<ProcessEntriesResponse> processIncludingMe(
+		@Parameter(description = "이벤트 ID", example = "1")
+		@PathVariable Long eventId
+	);
 }

--- a/backend/src/main/java/com/back/api/queue/controller/QueueEntryController.java
+++ b/backend/src/main/java/com/back/api/queue/controller/QueueEntryController.java
@@ -81,4 +81,19 @@ public class QueueEntryController implements QueueEntryApi {
 		return ApiResponse.ok("내 앞 사용들이 모두 입장 처리가 완료되었습니다.", response);
 	}
 
+	@Override
+	@PostMapping("/{eventId}/process-include-me")
+	public ApiResponse<ProcessEntriesResponse> processIncludingMe(
+		@PathVariable Long eventId
+	) {
+		Long userId = httpRequestContext.getUserId();
+
+		ProcessEntriesResponse response = queueEntryProcessService.processTopEntriesIncludingMeForTest(
+			eventId,
+			userId
+		);
+
+		return ApiResponse.ok("나를 포함한 내 앞 사용들이 모두 입장 처리가 완료되었습니다.", response);
+	}
+
 }


### PR DESCRIPTION
## 📌 개요
- 대기열 도메인 나를 포함한 상위 인원 모두 입장처리하는 API 추가(테스트용)

---

## ✨ 작업 내용
- 개요와 동일

---

## 🔗 관련 이슈
- close #204

---

## 🧪 체크리스트
- [ ] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [ ] 팀 내 코드 스타일 준수
- [ ] 이슈 연결
