### PR TITLE
refactor: 결제 완료 응답구조 변경

### DIFF
--- a/backend/src/main/java/com/back/api/payment/order/service/OrderService.java
+++ b/backend/src/main/java/com/back/api/payment/order/service/OrderService.java
@@ -8,15 +8,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.back.api.payment.order.dto.request.OrderRequestDto;
 import com.back.api.payment.order.dto.response.OrderResponseDto;
-import com.back.api.queue.service.QueueEntryProcessService;
 import com.back.api.ticket.service.TicketService;
-import com.back.domain.event.repository.EventRepository;
 import com.back.domain.payment.order.entity.Order;
 import com.back.domain.payment.order.entity.OrderStatus;
 import com.back.domain.payment.order.repository.OrderRepository;
-import com.back.domain.seat.repository.SeatRepository;
 import com.back.domain.ticket.entity.Ticket;
-import com.back.domain.user.repository.UserRepository;
 import com.back.global.error.code.OrderErrorCode;
 import com.back.global.error.code.PaymentErrorCode;
 import com.back.global.error.exception.ErrorException;
@@ -27,11 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OrderService {
 	private final OrderRepository orderRepository;
-	private final EventRepository eventRepository;
-	private final UserRepository userRepository;
-	private final SeatRepository seatRepository;
 	private final TicketService ticketService;
-	private final QueueEntryProcessService queueEntryProcessService;
 
 	/**
 	 * 주문 생성
@@ -71,7 +63,7 @@ public class OrderService {
 	 */
 	private String generateOrderNumber() {
 		Random random = new Random();
-		long number = 1000000000L + (long) (random.nextDouble() * 9000000000L);
+		long number = 1000000000L + (long)(random.nextDouble() * 9000000000L);
 		return "WF" + number;
 	}
 

--- a/backend/src/main/java/com/back/api/payment/payment/controller/PaymentApi.java
+++ b/backend/src/main/java/com/back/api/payment/payment/controller/PaymentApi.java
@@ -3,7 +3,7 @@ package com.back.api.payment.payment.controller;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.back.api.payment.payment.dto.request.PaymentConfirmRequest;
-import com.back.api.payment.payment.dto.response.PaymentConfirmResponse;
+import com.back.api.payment.payment.dto.response.PaymentReceiptResponse;
 import com.back.global.config.swagger.ApiErrorCode;
 import com.back.global.response.ApiResponse;
 
@@ -24,7 +24,7 @@ public interface PaymentApi {
 		"PAYMENT_AMOUNT_MISMATCH",
 		"PAYMENT_FAILED"
 	})
-	ApiResponse<PaymentConfirmResponse> confirmPayment(
+	ApiResponse<PaymentReceiptResponse> confirmPayment(
 		@Valid @RequestBody PaymentConfirmRequest request
 	);
 

--- a/backend/src/main/java/com/back/api/payment/payment/controller/PaymentController.java
+++ b/backend/src/main/java/com/back/api/payment/payment/controller/PaymentController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.back.api.payment.payment.dto.request.PaymentConfirmRequest;
-import com.back.api.payment.payment.dto.response.PaymentConfirmResponse;
+import com.back.api.payment.payment.dto.response.PaymentReceiptResponse;
 import com.back.api.payment.payment.service.PaymentService;
 import com.back.global.http.HttpRequestContext;
 import com.back.global.response.ApiResponse;
@@ -24,12 +24,12 @@ public class PaymentController implements PaymentApi {
 
 	@Override
 	@PostMapping("/confirm")
-	public ApiResponse<PaymentConfirmResponse> confirmPayment(
+	public ApiResponse<PaymentReceiptResponse> confirmPayment(
 		@Valid @RequestBody PaymentConfirmRequest request
 	) {
 		Long userId = httpRequestContext.getUser().getId();
 
-		PaymentConfirmResponse response = paymentService.confirmPayment(
+		PaymentReceiptResponse response = paymentService.confirmPayment(
 			request.orderId(),
 			request.paymentKey(),
 			request.amount(),

--- a/backend/src/main/java/com/back/api/payment/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/back/api/payment/payment/service/PaymentService.java
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.back.api.payment.order.service.OrderService;
 import com.back.api.payment.payment.client.PaymentClient;
 import com.back.api.payment.payment.dto.request.PaymentConfirmCommand;
-import com.back.api.payment.payment.dto.response.PaymentConfirmResponse;
 import com.back.api.payment.payment.dto.response.PaymentConfirmResult;
 import com.back.api.payment.payment.dto.response.PaymentReceiptResponse;
 import com.back.api.queue.service.QueueEntryProcessService;
@@ -43,7 +42,7 @@ public class PaymentService {
 	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional
-	public PaymentConfirmResponse confirmPayment(
+	public PaymentReceiptResponse confirmPayment(
 		Long orderId,
 		String clientPaymentKey,
 		Long clientAmount,
@@ -99,7 +98,13 @@ public class PaymentService {
 			)
 		);
 
-		return PaymentConfirmResponse.from(order, ticket);
+		// 최종 결과조회
+		// mock구성에서는 프론트 개발속도를 위해 confirmPayment에서 처리
+		// PG연동시에 분리 필요
+		order = orderService.getOrderWithDetails(orderId, userId);
+		ticket = order.getTicket();
+
+		return PaymentReceiptResponse.from(order, ticket);
 	}
 
 	/**


### PR DESCRIPTION
## 📌 개요
- 결제 완료 응답구조 변경

---

## ✨ 작업 내용
- 현재는 mock결제 client로 성공 응답만 반환되는 구조에서 POST /payment/confirm시에 응답값에 결제 영수증 정보를 담아두도록 변경

- 추후 PG연동을 고려할때,
  - 현재 /confirm 로직에 좌석/큐/티켓 상태변경 로직이 함께 담겨있는점
  - 실제 PG에서는 네트워크, PG api 자체가 실패 등의 케이스가 발생할 수 있는점
  - 등을 고려하면 트랜잭션의 관심사를 분리하는 것이 맞음
    - /confirm에서는 PG결제 성공에 따른 서버에서의 승인(pending되어있는 order/ticket/queue/seat)처리
    - /receipt에서는 서버에서의 /confirm 성공실패 여부에 따른 결과값 조회

- 프론트 구현 완성 속도를 위해 복잡도를 줄이고 추후 리팩토링/재설계하는 것으로 결정하겠음

---

## 🔗 관련 이슈
- close #213   

---

## 🧪 체크리스트
- [ ] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [ ] 팀 내 코드 스타일 준수
- [ ] 이슈 연결
