### PR TITLE
[refactor] 중복 어노테이션 클래스 단으로 이동 & 중복 api 제거

### DIFF
--- a/backend/src/main/java/com/back/api/event/controller/AdminEventController.java
+++ b/backend/src/main/java/com/back/api/event/controller/AdminEventController.java
@@ -25,13 +25,13 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/admin/events")
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminEventController implements AdminEventApi {
 
 	private final AdminEventService adminEventService;
 
 	@Override
 	@PostMapping
-	@PreAuthorize("hasRole('ADMIN')")
 	public ApiResponse<EventResponse> createEvent(
 		@Valid @RequestBody EventCreateRequest request) {
 		EventResponse response = adminEventService.createEvent(request);
@@ -40,7 +40,6 @@ public class AdminEventController implements AdminEventApi {
 
 	@Override
 	@PutMapping("/{eventId}")
-	@PreAuthorize("hasRole('ADMIN')")
 	public ApiResponse<EventResponse> updateEvent(
 		@PathVariable Long eventId,
 		@Valid @RequestBody EventUpdateRequest request) {
@@ -50,7 +49,6 @@ public class AdminEventController implements AdminEventApi {
 
 	@Override
 	@DeleteMapping("/{eventId}")
-	@PreAuthorize("hasRole('ADMIN')")
 	public ApiResponse<Void> deleteEvent(
 		@PathVariable Long eventId) {
 		adminEventService.deleteEvent(eventId);
@@ -59,7 +57,6 @@ public class AdminEventController implements AdminEventApi {
 
 	@Override
 	@GetMapping("/dashboard")
-	@PreAuthorize("hasRole('ADMIN')")
 	public ApiResponse<List<AdminEventDashboardResponse>> getAllEventsDashboard() {
 		List<AdminEventDashboardResponse> responses = adminEventService.getAllEventsDashboard();
 		return ApiResponse.ok("이벤트 현황 조회 성공", responses);

--- a/backend/src/main/java/com/back/api/event/controller/EventController.java
+++ b/backend/src/main/java/com/back/api/event/controller/EventController.java
@@ -22,13 +22,13 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/events")
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('NORMAL')")
 public class EventController implements EventApi {
 
 	private final EventService eventService;
 
 	@Override
 	@GetMapping("/{eventId}")
-	@PreAuthorize("hasRole('NORMAL')")
 	public ApiResponse<EventResponse> getEvent(
 		@PathVariable Long eventId) {
 		EventResponse response = eventService.getEvent(eventId);
@@ -37,7 +37,6 @@ public class EventController implements EventApi {
 
 	@Override
 	@GetMapping
-	@PreAuthorize("hasRole('NORMAL')")
 	public ApiResponse<Page<EventListResponse>> getEvents(
 		@RequestParam(required = false) EventStatus status,
 		@RequestParam(required = false) EventCategory category,

--- a/backend/src/main/java/com/back/api/seat/controller/AdminSeatController.java
+++ b/backend/src/main/java/com/back/api/seat/controller/AdminSeatController.java
@@ -24,15 +24,15 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/admin")
+@RequestMapping("/api/v1/admin/events/{eventId}/seats")
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminSeatController implements AdminSeatApi {
 
 	private final AdminSeatService adminSeatService;
 
 	@Override
-	@PostMapping("/events/{eventId}/seats/bulk")
-	@PreAuthorize("hasRole('ADMIN')")
+	@PostMapping("/bulk")
 	public ApiResponse<List<SeatResponse>> bulkCreateSeats(
 		@PathVariable Long eventId,
 		@Valid @RequestBody BulkCreateSeatsRequest request
@@ -49,8 +49,7 @@ public class AdminSeatController implements AdminSeatApi {
 	}
 
 	@Override
-	@PostMapping("/events/{eventId}/seats/auto")
-	@PreAuthorize("hasRole('ADMIN')")
+	@PostMapping("/auto")
 	public ApiResponse<List<SeatResponse>> autoCreateSeats(
 		@PathVariable Long eventId,
 		@Valid @RequestBody AutoCreateSeatsRequest request
@@ -68,8 +67,7 @@ public class AdminSeatController implements AdminSeatApi {
 	}
 
 	@Override
-	@PostMapping("/events/{eventId}/seats/single")
-	@PreAuthorize("hasRole('ADMIN')")
+	@PostMapping("/single")
 	public ApiResponse<SeatResponse> createSingleSeat(
 		@PathVariable Long eventId,
 		@Valid @RequestBody SeatCreateRequest request
@@ -80,8 +78,7 @@ public class AdminSeatController implements AdminSeatApi {
 	}
 
 	@Override
-	@PutMapping("/events/{eventId}/seats/{seatId}")
-	@PreAuthorize("hasRole('ADMIN')")
+	@PutMapping("/{seatId}")
 	public ApiResponse<SeatResponse> updateSeat(
 		@PathVariable Long eventId,
 		@PathVariable Long seatId,
@@ -93,8 +90,7 @@ public class AdminSeatController implements AdminSeatApi {
 	}
 
 	@Override
-	@DeleteMapping("/events/{eventId}/seats/{seatId}")
-	@PreAuthorize("hasRole('ADMIN')")
+	@DeleteMapping("/{seatId}")
 	public ApiResponse<Void> deleteSeat(
 		@PathVariable Long eventId,
 		@PathVariable Long seatId
@@ -105,8 +101,7 @@ public class AdminSeatController implements AdminSeatApi {
 	}
 
 	@Override
-	@DeleteMapping("/events/{eventId}/seats")
-	@PreAuthorize("hasRole('ADMIN')")
+	@DeleteMapping
 	public ApiResponse<Void> deleteAllEventSeats(
 		@PathVariable Long eventId
 	) {

--- a/backend/src/main/java/com/back/api/ticket/controller/TicketController.java
+++ b/backend/src/main/java/com/back/api/ticket/controller/TicketController.java
@@ -16,7 +16,7 @@ import com.back.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/tickets")
+@RequestMapping("/api/v1/tickets/my")
 @RequiredArgsConstructor
 public class TicketController implements TicketApi {
 
@@ -24,7 +24,7 @@ public class TicketController implements TicketApi {
 	private final HttpRequestContext httpRequestContext;
 
 	@Override
-	@GetMapping("/my")
+	@GetMapping
 	public ApiResponse<List<TicketResponse>> getMyTickets() {
 		Long userId = httpRequestContext.getUserId();
 
@@ -34,7 +34,7 @@ public class TicketController implements TicketApi {
 	}
 
 	@Override
-	@GetMapping("/my/{ticketId}/details")
+	@GetMapping("/{ticketId}/details")
 	public ApiResponse<TicketResponse> getMyTicketDetails(
 		@PathVariable Long ticketId
 	) {

--- a/backend/src/main/java/com/back/api/user/controller/UserController.java
+++ b/backend/src/main/java/com/back/api/user/controller/UserController.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 @Validated
+@PreAuthorize("hasRole('NORMAL')")
 public class UserController implements UserApi {
 
 	private final UserService userService;
@@ -28,7 +29,6 @@ public class UserController implements UserApi {
 
 	@Override
 	@GetMapping("/profile")
-	@PreAuthorize("hasRole('NORMAL')")
 	public ApiResponse<UserProfileResponse> getMe() {
 		long userId = httpRequestContext.getUserId();
 		UserProfileResponse response = userService.getUser(userId);
@@ -37,7 +37,6 @@ public class UserController implements UserApi {
 
 	@Override
 	@PutMapping("/profile")
-	@PreAuthorize("hasRole('NORMAL')")
 	public ApiResponse<UserProfileResponse> updateProfile(
 		@Validated @RequestBody UpdateProfileRequest request
 	) {
@@ -48,7 +47,6 @@ public class UserController implements UserApi {
 
 	@Override
 	@DeleteMapping("/me")
-	@PreAuthorize("hasRole('NORMAL')")
 	public ApiResponse<Void> deleteUser() {
 		long userUd = httpRequestContext.getUserId();
 		userService.deleteUser(userUd);


### PR DESCRIPTION
## 📌 개요
- 기존@PreAuthorize 어노테이션이 메서드마다 붙어있었는데, 클래스에 있는 모든 메서드가 동일한 권한일 경우에는 메서드마다 각자 붙이는 것보다 클래스단에 한번만 붙이는 게 깔끔하기 때문에 그 부분 수정하였습니다. (QueueEntryAdmin은 이전 PR에서 수정했기 때문에 해당 PR에서는 수정하지 않았습니다.)
- 또한 저번에 멘토님이 코드 리뷰때 말씀해주셨던 내용인 공통적인 API는 RequestMapping으로 빼도록 수정하였습니다.

---

## ✨ 작업 내용
- 개요와 동일

---

## 🔗 관련 이슈
- close #221

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
