### PR TITLE
[refactor] 사전등록 및 티켓팅한 사용자 회원탈퇴 로직 보완

### DIFF
--- a/backend/src/main/java/com/back/api/ticket/service/TicketService.java
+++ b/backend/src/main/java/com/back/api/ticket/service/TicketService.java
@@ -1,5 +1,6 @@
 package com.back.api.ticket.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -171,6 +172,10 @@ public class TicketService {
 	@Transactional(readOnly = true)
 	public List<TicketResponse> getMyTickets(Long userId) {
 		return ticketRepository.findMyTicketDto(userId);
+	}
+
+	public List<Ticket> getMyIssuedOrPaidTicketsBeforeEvent(Long userId) {
+		return ticketRepository.findIssuedOrPaidBeforeEvent(userId, LocalDateTime.now());
 	}
 
 	/**

--- a/backend/src/main/java/com/back/api/user/service/UserService.java
+++ b/backend/src/main/java/com/back/api/user/service/UserService.java
@@ -1,14 +1,20 @@
 package com.back.api.user.service;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.back.api.queue.service.QueueEntryProcessService;
+import com.back.api.queue.service.QueueEntryReadService;
+import com.back.api.ticket.service.TicketService;
 import com.back.api.auth.service.ActiveSessionCache;
 import com.back.api.user.dto.request.UpdateProfileRequest;
 import com.back.api.user.dto.response.UserProfileResponse;
 import com.back.domain.auth.repository.RefreshTokenRepository;
+import com.back.domain.queue.entity.QueueEntry;
+import com.back.domain.ticket.entity.Ticket;
 import com.back.domain.user.entity.User;
 import com.back.domain.user.repository.UserRepository;
 import com.back.global.error.code.AuthErrorCode;
@@ -17,16 +23,22 @@ import com.back.global.error.exception.ErrorException;
 import com.back.global.http.HttpRequestContext;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserService {
 
 	private final UserRepository userRepository;
 	private final RefreshTokenRepository refreshTokenRepository;
 	private final ActiveSessionCache activeSessionCache;
 	private final HttpRequestContext requestContext;
+	private final QueueEntryReadService queueEntryReadService;
+	private final QueueEntryProcessService queueEntryProcessService;
+	private final TicketService ticketService;
 
+	@Transactional
 	public UserProfileResponse getUser(Long userId) {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new ErrorException(UserErrorCode.NOT_FOUND));
@@ -59,6 +71,8 @@ public class UserService {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new ErrorException(UserErrorCode.NOT_FOUND));
 
+		handleDeleteUserQueue(userId);
+
 		// 모든 기기의 refreshToken 무효화 (전 기기 로그아웃 효과)
 		refreshTokenRepository.revokeAllByUserId(userId);
 
@@ -69,5 +83,33 @@ public class UserService {
 		requestContext.deleteAuthCookies();
 
 		user.softDelete();
+	}
+
+	private void handleDeleteUserQueue(long userId) {
+		// 1. 사전등록 인원: 랜덤 큐 스케줄러 동작 전까지 회원탈퇴 가능
+		List<QueueEntry> waitingOrEnteredQueues = queueEntryReadService.getWaitingOrEnteredQueues(userId);
+
+		// 2. 티켓을 구매한 상태면 행사 오픈날짜가 지나고 회원탈퇴 할 수 있도록 하기
+		List<Ticket> tickets = ticketService.getMyIssuedOrPaidTicketsBeforeEvent(userId);
+
+		if (waitingOrEnteredQueues.isEmpty() && tickets.isEmpty()) {
+			return;
+		}
+
+		// 랜덤 큐에 배정된 이후회원 탈퇴를 시도하면, 사용자 삭제: 배정된 랜덤큐에서 해당 사옹자 제거
+		if (!waitingOrEnteredQueues.isEmpty() && tickets.isEmpty()) {
+			removeUserInQueues(waitingOrEnteredQueues, userId);
+			log.info("Success remove WAITING|ENTERED queues for deleted userId: {}", userId);
+			return;
+		}
+
+		log.error("Can't delete user for userId: {}", userId);
+		throw new ErrorException(UserErrorCode.CAN_NOT_DELETE_USER);
+	}
+
+	private void removeUserInQueues(List<QueueEntry> queues, long userId) {
+		for (QueueEntry queue : queues) {
+			queueEntryProcessService.expireWaitingAndEnteredEntry(queue.getEventId(), userId);
+		}
 	}
 }

--- a/backend/src/main/java/com/back/domain/queue/repository/QueueEntryRedisRepository.java
+++ b/backend/src/main/java/com/back/domain/queue/repository/QueueEntryRedisRepository.java
@@ -92,13 +92,25 @@ public class QueueEntryRedisRepository {
 		log.info("Removed user from entered queue - eventId: {}, userId: {}", eventId, userId);
 	}
 
+	public void removeFromWaitingAndEnteredQueue(Long eventId, Long userId) {
+		// WAITING 제거
+		String waitingKey = String.format(WAITING_KEY, eventId);
+		redisTemplate.opsForZSet().remove(waitingKey, userId.toString());
+
+		// ENTERED 제거
+		String enteredKey = String.format(ENTERED_KEY, eventId);
+		redisTemplate.opsForSet().remove(enteredKey, userId.toString());
+
+		log.info("Removed user from waiting & entered queue - eventId: {}, userId: {}", eventId, userId);
+	}
+
 	public Long getTotalEnteredCount(Long eventId) {
 		String key = String.format(ENTERED_KEY, eventId);
 		Long size = redisTemplate.opsForSet().size(key);
 		return size != null ? size : 0L;
 	}
 
-	public boolean  isInEnteredQueue(Long eventId, Long userId) {
+	public boolean isInEnteredQueue(Long eventId, Long userId) {
 		String key = String.format(ENTERED_KEY, eventId);
 		Boolean isMember = redisTemplate.opsForSet().isMember(key, userId.toString());
 		return isMember != null && isMember;
@@ -115,7 +127,6 @@ public class QueueEntryRedisRepository {
 		Object count = redisTemplate.opsForValue().get(key);
 		return count != null ? (Long)count : 0L;
 	}
-
 
 	/* ==================== 임시 데이터 추가용 ==================== */
 	public void addToEnteredQueueDirectly(Long eventId, Long userId) {

--- a/backend/src/main/java/com/back/domain/queue/repository/QueueEntryRepository.java
+++ b/backend/src/main/java/com/back/domain/queue/repository/QueueEntryRepository.java
@@ -52,6 +52,9 @@ public interface QueueEntryRepository extends JpaRepository<QueueEntry, Long> {
 		@Param("eventId") Long eventId
 	);
 
+	@Query("SELECT q FROM QueueEntry q WHERE q.user.id = :userId")
+	List<QueueEntry> findAllByUserId(@Param("userId") Long userId);
+
 	@Query("SELECT q FROM QueueEntry q "
 		+ "JOIN FETCH q.user u "
 		+ "JOIN FETCH q.event e "

--- a/backend/src/main/java/com/back/domain/ticket/repository/TicketRepositoryCustom.java
+++ b/backend/src/main/java/com/back/domain/ticket/repository/TicketRepositoryCustom.java
@@ -1,11 +1,14 @@
 package com.back.domain.ticket.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.back.api.ticket.dto.response.TicketResponse;
+import com.back.domain.ticket.entity.Ticket;
 
 public interface TicketRepositoryCustom {
 
 	List<TicketResponse> findMyTicketDto(Long userId);
 
+	List<Ticket> findIssuedOrPaidBeforeEvent(Long userId, LocalDateTime now);
 }

--- a/backend/src/main/java/com/back/domain/ticket/repository/TicketRepositoryImpl.java
+++ b/backend/src/main/java/com/back/domain/ticket/repository/TicketRepositoryImpl.java
@@ -4,11 +4,13 @@ import static com.back.domain.event.entity.QEvent.*;
 import static com.back.domain.seat.entity.QSeat.*;
 import static com.back.domain.ticket.entity.QTicket.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
 import com.back.api.ticket.dto.response.TicketResponse;
+import com.back.domain.ticket.entity.Ticket;
 import com.back.domain.ticket.entity.TicketStatus;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -51,5 +53,18 @@ public class TicketRepositoryImpl implements TicketRepositoryCustom {
 			.orderBy(ticket.createAt.desc())
 			.fetch();
 
+	}
+
+	@Override
+	public List<Ticket> findIssuedOrPaidBeforeEvent(Long userId, LocalDateTime now) {
+		return jpaQueryFactory
+			.selectFrom(ticket)
+			.join(ticket.event, event).fetchJoin()
+			.where(
+				ticket.owner.id.eq(userId),
+				ticket.ticketStatus.in(TicketStatus.ISSUED, TicketStatus.PAID),
+				event.eventDate.after(now)
+			)
+			.fetch();
 	}
 }

--- a/backend/src/main/java/com/back/global/error/code/UserErrorCode.java
+++ b/backend/src/main/java/com/back/global/error/code/UserErrorCode.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-	NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+	NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+	CAN_NOT_DELETE_USER(HttpStatus.BAD_REQUEST, "신청하신 행사가 종료된 후에 탈퇴 할 수 있습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/backend/src/test/java/com/back/support/factory/EventFactory.java
+++ b/backend/src/test/java/com/back/support/factory/EventFactory.java
@@ -139,4 +139,26 @@ public class EventFactory extends BaseFactory {
 			.status(EventStatus.OPEN)
 			.build();
 	}
+
+	public static Event fakePastEvent(String title) {
+		int minPrice = faker.number().numberBetween(10000, 50000);
+		int maxPrice = faker.number().numberBetween(minPrice, 200000);
+
+		return Event.builder()
+			.title(title)
+			.category(EventCategory.CONCERT)
+			.description(faker.lorem().sentence())
+			.place(faker.address().city())
+			.imageUrl(faker.internet().image())
+			.minPrice(minPrice)
+			.maxPrice(maxPrice)
+			.preOpenAt(LocalDateTime.now().minusDays(40))
+			.preCloseAt(LocalDateTime.now().minusDays(38))
+			.ticketOpenAt(LocalDateTime.now().minusDays(37))
+			.ticketCloseAt(LocalDateTime.now().minusDays(10))
+			.eventDate(LocalDateTime.now().minusDays(1)) // 이미 지난 날짜
+			.maxTicketAmount(faker.number().numberBetween(1000, 10000))
+			.status(EventStatus.OPEN)
+			.build();
+	}
 }

--- a/backend/src/test/java/com/back/support/helper/EventHelper.java
+++ b/backend/src/test/java/com/back/support/helper/EventHelper.java
@@ -37,6 +37,10 @@ public class EventHelper {
 		return eventRepository.save(EventFactory.fakeReadyEvent());
 	}
 
+	public Event createPastEvent(String title) {
+		return eventRepository.save(EventFactory.fakePastEvent(title));
+	}
+
 	public void clearEvent() {
 		eventRepository.deleteAll();
 	}


### PR DESCRIPTION
## 📌 개요
- 사전등록 및 티켓팅한 사용자 회원탈퇴 로직 보완

---

## ✨ 작업 내용
- 아래의 정책에 따라 회원탈퇴 처리
   - 사전등록 인원: 랜덤 큐 스케줄러 동작 전까지 회원탈퇴 가능
   - 랜덤 큐에 배정된 이후회원 탈퇴를 시도하면, "현재 우선순위 배정 진행 중입니다. 그래도 탈퇴하시겠습니까?" 물어보기
      - "예"를 선택: 우선순위에서 탈퇴 사용자를 제외, (예시: 총 사전인원 100명, 수용인원 10명, 탈퇴사용자 우선순위가 3번인 경우, 탈퇴를 하면, [1, 2, 4, 5, 6, 7, 8, 9, 10, 11] 우선순위를 처리
   - 티켓을 구매한 상태면 행사 오픈날짜가 지나고 회원탈퇴 할 수 있도록 하기

**[티켓을 구매하고 행사 날짜 이전에 회원탈퇴를 시도하는 경우]**
<img width="910" height="768" alt="Screenshot 2025-12-29 at 5 43 10 PM" src="https://github.com/user-attachments/assets/916b829f-dfff-4125-8afc-a859b43bb068" />

**[대기열 큐에서 Waiting 상태인 사용자가 회원탈퇴를 하는 경우, Expired로 업데이트 및 redis에서 삭제]**
<img width="1473" height="971" alt="Screenshot 2025-12-29 at 5 59 41 PM" src="https://github.com/user-attachments/assets/9b1e1dbb-e2e0-430e-adc8-24445c405814" />


---

## 🔗 관련 이슈
- close #244   

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
