### PR TITLE
[refactor] Event 목록 및 상세 페이지 로그인하지 않더라도 접근 가능하도록 수정

### DIFF
--- a/backend/src/main/java/com/back/api/event/controller/EventController.java
+++ b/backend/src/main/java/com/back/api/event/controller/EventController.java
@@ -3,7 +3,6 @@ package com.back.api.event.controller;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +21,6 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/events")
 @RequiredArgsConstructor
-@PreAuthorize("hasRole('NORMAL')")
 public class EventController implements EventApi {
 
 	private final EventService eventService;

--- a/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -45,6 +45,10 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 		"/api/v1/auth/signup"
 	);
 
+	private static final Set<String> PATH_PREFIX_WHITELIST = Set.of(
+		"/api/v1/events"
+	);
+
 	private final JwtProvider jwtProvider;
 	private final AuthTokenService tokenService;
 	private final CookieManager cookieManager;
@@ -87,6 +91,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 		if ("OPTIONS".equalsIgnoreCase(request.getMethod())
 			|| !requestUrl.startsWith("/api/")
 			|| AUTH_WHITELIST.contains(requestUrl)
+			|| isWhitelistedPath(requestUrl)
 		) {
 			filterChain.doFilter(request, response);
 			return;
@@ -139,6 +144,19 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 		} finally {
 			MdcContext.removeUserId(); // 다음 스레드 재사용을 위해 반드시 제거
 		}
+	}
+
+	private boolean isWhitelistedPath(String requestUrl) {
+		for (String prefix : PATH_PREFIX_WHITELIST) {
+			if (requestUrl.startsWith(prefix)) {
+				// /api/v1/events로 시작하지만 /pre-registers를 포함하는 경우 제외
+				if (requestUrl.contains("/pre-registers")) {
+					return false;
+				}
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private void handleErrorException(

--- a/backend/src/test/java/com/back/api/event/controller/EventControllerTest.java
+++ b/backend/src/test/java/com/back/api/event/controller/EventControllerTest.java
@@ -76,6 +76,20 @@ class EventControllerTest {
 		}
 
 		@Test
+		@DisplayName("비회원도 이벤트 단건 조회 가능")
+		void getEvent_Success_WithoutAuth() throws Exception {
+			// given
+			Event event = eventRepository.save(EventFactory.fakeEvent("비회원 조회 이벤트"));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/events/{eventId}", event.getId()))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.id").value(event.getId()))
+				.andExpect(jsonPath("$.data.title").value("비회원 조회 이벤트"));
+		}
+
+		@Test
 		@DisplayName("존재하지 않는 이벤트 조회 시 404 에러")
 		void getEvent_Fail_NotFound() throws Exception {
 			// when & then
@@ -105,6 +119,23 @@ class EventControllerTest {
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.data.content", hasSize(2)));
+		}
+
+		@Test
+		@DisplayName("비회원도 이벤트 목록 조회 가능")
+		void getEvents_Success_WithoutAuth() throws Exception {
+			// given
+			eventRepository.save(EventFactory.fakeEvent("비회원 이벤트1"));
+			eventRepository.save(EventFactory.fakeEvent("비회원 이벤트2"));
+			eventRepository.save(EventFactory.fakeEvent("비회원 이벤트3"));
+
+			// when & then
+			mockMvc.perform(get("/api/v1/events")
+					.param("page", "0")
+					.param("size", "10"))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.content", hasSize(greaterThanOrEqualTo(3))));
 		}
 
 		@Test


### PR DESCRIPTION
## 📌 개요
- Event 목록 및 상세 페이지 로그인하지 않더라도 접근 가능하도록 수정
- 비회원도 이벤트 탭 사용 가능

---

## ✨ 작업 내용
- 개요와 동일
<img width="1223" height="756" alt="스크린샷 2025-12-30 오전 11 27 25" src="https://github.com/user-attachments/assets/e2cc2930-f9a7-472f-89dc-60a5e4e314bd" />


---

## 🔗 관련 이슈
- close #267   

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
