### PR TITLE
[fix] preRegister 보안 코드 헬스체크 DEBUG 로그 제거

### DIFF
--- a/backend/src/main/java/com/back/global/security/filter/IdcBlockFilter.java
+++ b/backend/src/main/java/com/back/global/security/filter/IdcBlockFilter.java
@@ -74,7 +74,6 @@ public class IdcBlockFilter extends OncePerRequestFilter {
 
 		// AWS ALB 헬스체크는 무조건 통과 (서버 무한 재부팅 방지)
 		if (isHealthCheckRequest(request, requestUri)) {
-			log.debug("[IdcBlockFilter] 헬스체크 요청 통과 - IP: {}, URI: {}", clientIp, requestUri);
 			filterChain.doFilter(request, response);
 			return;
 		}

--- a/backend/src/main/java/com/back/global/security/util/ClientIpResolver.java
+++ b/backend/src/main/java/com/back/global/security/util/ClientIpResolver.java
@@ -65,7 +65,6 @@ public class ClientIpResolver {
 		// 모든 헤더에서 IP를 찾지 못한 경우 RemoteAddr 사용
 		if (isInvalidIp(ip)) {
 			ip = request.getRemoteAddr();
-			log.debug("IP 추출: RemoteAddr 사용 - IP: {}", ip);
 		}
 
 		return ip;


### PR DESCRIPTION
## 📌 개요
- ClientIpResolver의 RemoteAddr 사용 로그 제거
- IdcBlockFilter의 헬스체크 통과 로그 제거
- 실패/차단 시에만 WARN 로그 출력되도록 유지

---

## ✨ 작업 내용
- 개요와 동일

---

## 🔗 관련 이슈
- close #312 

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
