### PR TITLE
[feat] 카카오 회원가입/로그인 추가

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
 
     implementation("org.springframework.boot:spring-boot-starter-batch")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     testImplementation("org.springframework.batch:spring-batch-test")
 
     implementation("org.springframework.boot:spring-boot-starter-security")

--- a/backend/src/main/java/com/back/api/auth/controller/AuthApi.java
+++ b/backend/src/main/java/com/back/api/auth/controller/AuthApi.java
@@ -3,6 +3,7 @@ package com.back.api.auth.controller;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.back.api.auth.dto.request.LoginRequest;
+import com.back.api.auth.dto.request.OAuthExchangeRequest;
 import com.back.api.auth.dto.request.SignupRequest;
 import com.back.api.auth.dto.request.VerifyPasswordRequest;
 import com.back.api.auth.dto.response.AuthResponse;
@@ -43,4 +44,7 @@ public interface AuthApi {
 		"PASSWORD_MISMATCH"
 	})
 	ApiResponse<Void> verifyPassword(@Valid @RequestBody VerifyPasswordRequest request);
+
+	@Operation(summary = "토큰 조회", description = "SNS 로그인 후 토큰 조회")
+	ApiResponse<AuthResponse> exchange(@Valid @RequestBody OAuthExchangeRequest request);
 }

--- a/backend/src/main/java/com/back/api/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/back/api/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.back.api.auth.dto.request.LoginRequest;
+import com.back.api.auth.dto.request.OAuthExchangeRequest;
 import com.back.api.auth.dto.request.SignupRequest;
 import com.back.api.auth.dto.request.VerifyPasswordRequest;
 import com.back.api.auth.dto.response.AuthResponse;
@@ -54,5 +55,12 @@ public class AuthController implements AuthApi {
 	public ApiResponse<Void> verifyPassword(@Valid @RequestBody VerifyPasswordRequest request) {
 		authService.verifyPassword(request.password());
 		return ApiResponse.noContent("비밀번호 인증 완료");
+	}
+
+	@Override
+	@PostMapping("/oauth/exchange")
+	public ApiResponse<AuthResponse> exchange(@Valid @RequestBody OAuthExchangeRequest request) {
+		AuthResponse result = authService.exchange(request);
+		return ApiResponse.ok(result);
 	}
 }

--- a/backend/src/main/java/com/back/api/auth/dto/request/OAuthExchangeRequest.java
+++ b/backend/src/main/java/com/back/api/auth/dto/request/OAuthExchangeRequest.java
@@ -1,0 +1,12 @@
+package com.back.api.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "소셜 로그인 토큰 요청 DTO")
+public record OAuthExchangeRequest(
+	@Schema(description = "인코딩된 토큰 정보")
+	@NotBlank(message = "code 는 필수입니다.")
+	String code
+) {
+}

--- a/backend/src/main/java/com/back/api/auth/service/SocialAuthService.java
+++ b/backend/src/main/java/com/back/api/auth/service/SocialAuthService.java
@@ -1,0 +1,61 @@
+package com.back.api.auth.service;
+
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.domain.auth.entity.ProviderType;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserActiveStatus;
+import com.back.domain.user.entity.UserRole;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.error.code.AuthErrorCode;
+import com.back.global.error.exception.ErrorException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SocialAuthService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	public User join(String providerId, String nickname, String password, ProviderType providerType) {
+		if (userRepository.existsByNickname(nickname)) {
+			throw new ErrorException(AuthErrorCode.ALREADY_EXIST_NICKNAME);
+		}
+
+		String raw = StringUtils.isBlank(password) ? UUID.randomUUID().toString() : password;
+		String encodedPassword = passwordEncoder.encode(raw);
+
+		User user = User.builder()
+			.email(null)
+			.nickname(nickname)
+			.fullName(nickname)
+			.password(encodedPassword)
+			.providerType(providerType)
+			.activeStatus(UserActiveStatus.ACTIVE)
+			.role(UserRole.NORMAL)
+			.providerId(providerId)
+			.build();
+
+		return userRepository.save(user);
+	}
+
+	public User modifyOrJoin(String providerId, String nickname, String password, ProviderType providerType) {
+		User user = userRepository.findByProviderId(providerId).orElse(null);
+
+		if (user == null) {
+			return join(providerId, nickname, password, providerType);
+		}
+
+		user.update(nickname, nickname, null);
+
+		return user;
+	}
+}

--- a/backend/src/main/java/com/back/api/auth/store/OAuthExchangeCodeStore.java
+++ b/backend/src/main/java/com/back/api/auth/store/OAuthExchangeCodeStore.java
@@ -1,0 +1,44 @@
+package com.back.api.auth.store;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthExchangeCodeStore {
+
+	private static final String KEY_PREFIX = "oauth:exchange:";
+	private static final Duration TTL = Duration.ofSeconds(60);
+
+	private final StringRedisTemplate stringRedisTemplate;
+
+	public String issue(Long userId) {
+		String code = UUID.randomUUID().toString().replace("-", "");
+		String key = KEY_PREFIX + code;
+		stringRedisTemplate.opsForValue().set(key, userId.toString(), TTL);
+		return code;
+	}
+
+	public Optional<Long> consume(String code) {
+		if (StringUtils.isBlank(code)) {
+			return Optional.empty();
+		}
+
+		String key = KEY_PREFIX + code;
+
+		String userIdStr = stringRedisTemplate.opsForValue().get(key);
+		if (StringUtils.isBlank(userIdStr)) {
+			return Optional.empty();
+		}
+
+		stringRedisTemplate.delete(key);
+		return Optional.of(Long.parseLong(userIdStr));
+	}
+}

--- a/backend/src/main/java/com/back/domain/auth/entity/ProviderType.java
+++ b/backend/src/main/java/com/back/domain/auth/entity/ProviderType.java
@@ -1,0 +1,6 @@
+package com.back.domain.auth.entity;
+
+public enum ProviderType {
+	LOCAL,
+	KAKAO
+}

--- a/backend/src/main/java/com/back/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/back/domain/auth/repository/RefreshTokenRepository.java
@@ -39,4 +39,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 	int revokeAllActiveByUserId(@Param("userId") long userId);
 
 	Optional<RefreshToken> findByUserIdAndRevokedFalse(Long userId);
+
+	Optional<RefreshToken> findByTokenAndRevokedFalse(String refreshHash);
 }

--- a/backend/src/main/java/com/back/domain/user/entity/User.java
+++ b/backend/src/main/java/com/back/domain/user/entity/User.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.FilterDef;
 
+import com.back.domain.auth.entity.ProviderType;
 import com.back.domain.store.entity.Store;
 import com.back.global.entity.BaseEntity;
 
@@ -46,7 +47,7 @@ public class User extends BaseEntity {
 	)
 	private Long id;
 
-	@Column(nullable = false, length = 100, unique = true)
+	@Column(length = 100)
 	private String email;
 
 	@Column(nullable = false, name = "full_name", length = 30)
@@ -72,13 +73,21 @@ public class User extends BaseEntity {
 	@Column(name = "deleted_at")
 	private LocalDateTime deleteDate;
 
+	@Enumerated(EnumType.STRING)
+	@Column(name = "provider_type")
+	private ProviderType providerType;
+
+	@Column(name = "provider_id")
+	private String providerId;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "store_id", foreignKey = @ForeignKey(name = "fk_user_store"))
 	private Store store;
 
 	@Builder
 	public User(String email, String fullName, String nickname, String password,
-		LocalDate birthDate, UserRole role, UserActiveStatus activeStatus, Store store) {
+		LocalDate birthDate, UserRole role, UserActiveStatus activeStatus, Store store,
+		String providerId, ProviderType providerType) {
 		this.email = email;
 		this.fullName = fullName;
 		this.nickname = nickname;
@@ -87,6 +96,8 @@ public class User extends BaseEntity {
 		this.role = role;
 		this.activeStatus = activeStatus;
 		this.store = store;
+		this.providerId = providerId;
+		this.providerType = providerType;
 	}
 
 	public void update(String fullName, String nickname, LocalDate birthDate) {

--- a/backend/src/main/java/com/back/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/back/domain/user/repository/UserRepository.java
@@ -19,4 +19,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	@Query(value = "SELECT * FROM users WHERE id = :id", nativeQuery = true)
 	Optional<User> findIncludingDeletedById(@Param("id") Long id);
+
+	Optional<User> findByProviderId(String providerId);
 }

--- a/backend/src/main/java/com/back/global/config/RedisStringConfig.java
+++ b/backend/src/main/java/com/back/global/config/RedisStringConfig.java
@@ -1,0 +1,16 @@
+package com.back.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisStringConfig {
+	@Bean
+	public StringRedisTemplate stringRedisTemplate(
+		RedisConnectionFactory connectionFactory
+	) {
+		return new StringRedisTemplate(connectionFactory);
+	}
+}

--- a/backend/src/main/java/com/back/global/config/SecurityConfigPerfDev.java
+++ b/backend/src/main/java/com/back/global/config/SecurityConfigPerfDev.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -18,23 +19,33 @@ import com.back.global.error.code.AuthErrorCode;
 import com.back.global.error.code.ErrorCode;
 import com.back.global.observability.RequestIdFilter;
 import com.back.global.properties.CorsProperties;
+import com.back.global.properties.SiteProperties;
 import com.back.global.response.ApiResponse;
 import com.back.global.security.CustomAuthenticationFilter;
+import com.back.global.security.oauth.CustomOAuth2AuthorizationRequestResolver;
+import com.back.global.security.oauth.CustomOAuth2LoginSuccessHandler;
+import com.back.global.security.oauth.CustomOAuth2UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 @Profile({"perf", "dev"})
 @RequiredArgsConstructor
+@Slf4j
 public class SecurityConfigPerfDev {
 
 	private final CorsProperties corsProperties;
+	private final SiteProperties siteProperties;
 	private final CustomAuthenticationFilter authenticationFilter;
 	private final ObjectMapper objectMapper;
+	private final CustomOAuth2LoginSuccessHandler customOAuth2LoginSuccessHandler;
+	private final CustomOAuth2AuthorizationRequestResolver customOAuth2AuthorizationRequestResolver;
+	private final CustomOAuth2UserService customOAuth2UserService;
 
 	@Bean
 	public RequestIdFilter requestIdFilter() {
@@ -55,6 +66,20 @@ public class SecurityConfigPerfDev {
 			)
 			// ✅ perf/local에서는 CSRF를 통째로 끄는 게 보통 편함 (curl/seed 때문)
 			.csrf(csrf -> csrf.disable())
+			.sessionManagement(sessionManagement ->
+				sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.oauth2Login(oauth2 -> {
+				oauth2
+					.successHandler(customOAuth2LoginSuccessHandler)
+					.authorizationEndpoint(authorizationEndPoint ->
+						authorizationEndPoint.authorizationRequestResolver(customOAuth2AuthorizationRequestResolver))
+					.userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint.userService(customOAuth2UserService))
+					.failureHandler((req, res, ex) -> {
+						log.error("OAuth2 login failed", ex);
+						writeError(res, AuthErrorCode.SOCIAL_LOGIN_FAILED);
+						res.sendRedirect(siteProperties.getFrontUrl());
+					});
+			})
 			.exceptionHandling(ex -> ex
 				.authenticationEntryPoint((req, res, e) -> writeError(res, AuthErrorCode.UNAUTHORIZED))
 				.accessDeniedHandler((req, res, e) -> writeError(res, AuthErrorCode.FORBIDDEN))
@@ -62,6 +87,10 @@ public class SecurityConfigPerfDev {
 
 		http.addFilterBefore(requestIdFilter, UsernamePasswordAuthenticationFilter.class);
 		http.addFilterAfter(authenticationFilter, RequestIdFilter.class);
+
+		http
+			.formLogin(form -> form.disable())
+			.httpBasic(basic -> basic.disable());
 
 		return http.build();
 	}

--- a/backend/src/main/java/com/back/global/error/code/AuthErrorCode.java
+++ b/backend/src/main/java/com/back/global/error/code/AuthErrorCode.java
@@ -24,6 +24,7 @@ public enum AuthErrorCode implements ErrorCode {
 	REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레시 토큰을 찾을 수 없습니다."),
 
 	LOGIN_FAILED(HttpStatus.BAD_REQUEST, "이메일과 비밀번호가 올바른지 확인해주세요."),
+	SOCIAL_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "로그인에 실패했습니다. 다시 시도해주세요."),
 
 	PASSWORD_MISMATCH(HttpStatus.NOT_FOUND, "비밀번호가 일치하지 않습니다.");
 

--- a/backend/src/main/java/com/back/global/http/HttpRequestContext.java
+++ b/backend/src/main/java/com/back/global/http/HttpRequestContext.java
@@ -1,5 +1,6 @@
 package com.back.global.http;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -138,5 +139,9 @@ public class HttpRequestContext {
 
 	public void deleteAuthCookies() {
 		cookieManager.deleteAuthCookies(request, response);
+	}
+
+	public void sendRedirect(String url) throws IOException {
+		response.sendRedirect(url);
 	}
 }

--- a/backend/src/main/java/com/back/global/security/SecurityUser.java
+++ b/backend/src/main/java/com/back/global/security/SecurityUser.java
@@ -1,17 +1,19 @@
 package com.back.global.security;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import com.back.domain.user.entity.UserRole;
 
 import lombok.Getter;
 
 @Getter
-public class SecurityUser extends User {
+public class SecurityUser extends User implements OAuth2User {
 
 	private Long id;
 	private String nickname;
@@ -31,5 +33,15 @@ public class SecurityUser extends User {
 		this.nickname = nickname;
 		this.role = role;
 		this.storeId = storeId;
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return Map.of();
+	}
+
+	@Override
+	public String getName() {
+		return nickname;
 	}
 }

--- a/backend/src/main/java/com/back/global/security/oauth/CustomOAuth2AuthorizationRequestResolver.java
+++ b/backend/src/main/java/com/back/global/security/oauth/CustomOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,75 @@
+package com.back.global.security.oauth;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import com.back.global.properties.SiteProperties;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+	private final ClientRegistrationRepository clientRegistrationRepository;
+
+	private final SiteProperties siteProperties;
+
+	private DefaultOAuth2AuthorizationRequestResolver defaultResolver() {
+		return new DefaultOAuth2AuthorizationRequestResolver(
+			clientRegistrationRepository,
+			OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI
+		);
+	}
+
+	@Override
+	public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+		OAuth2AuthorizationRequest req = defaultResolver().resolve(request);
+		return customizeState(req, request);
+	}
+
+	@Override
+	public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+		OAuth2AuthorizationRequest req = defaultResolver().resolve(request, clientRegistrationId);
+		return customizeState(req, request);
+	}
+
+	private OAuth2AuthorizationRequest customizeState(OAuth2AuthorizationRequest authorizationRequest,
+		HttpServletRequest req) {
+
+		//OAuth 요청이 아닐 때는 넘어감
+		if (authorizationRequest == null) {
+			return null;
+		}
+
+		String redirectUrl = req.getParameter("redirectUrl");
+
+		if (StringUtils.isBlank(redirectUrl)) {
+			redirectUrl = siteProperties.getFrontUrl();
+		}
+
+		String originState = authorizationRequest.getState();
+		if (originState == null) {
+			originState = "";
+		}
+
+		String newState = originState + "#" + redirectUrl;
+
+		// 특수문자가 포함된 경우 Base64로 인코딩
+		String encodedNewState = Base64.getUrlEncoder()
+			.withoutPadding()
+			.encodeToString(newState.getBytes(StandardCharsets.UTF_8));
+
+		return OAuth2AuthorizationRequest.from(authorizationRequest)
+			.state(encodedNewState)
+			.build();
+	}
+}

--- a/backend/src/main/java/com/back/global/security/oauth/CustomOAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/back/global/security/oauth/CustomOAuth2LoginSuccessHandler.java
@@ -1,0 +1,62 @@
+package com.back.global.security.oauth;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.back.api.auth.store.OAuthExchangeCodeStore;
+import com.back.global.http.HttpRequestContext;
+import com.back.global.properties.SiteProperties;
+import com.back.global.security.SecurityUser;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+	private final HttpRequestContext httpRequestContext;
+	private final SiteProperties siteProperties;
+	private final OAuthExchangeCodeStore codeStore;
+
+	@Override
+	public void onAuthenticationSuccess(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		Authentication authentication
+	) throws IOException {
+		SecurityUser securityUser = (SecurityUser)authentication.getPrincipal();
+		Long userId = securityUser.getId();
+
+		String state = request.getParameter("state");
+		String redirectUrl = siteProperties.getFrontUrl() + "/oauth/callback";
+
+		if (state != null && !state.isBlank()) {
+			String decoded = new String(Base64.getUrlDecoder().decode(state), StandardCharsets.UTF_8);
+			int idx = decoded.indexOf('#');
+			log.info("Provider OAuth2 decoded: {}", decoded);
+			if (idx >= 0 && idx + 1 < decoded.length()) {
+				redirectUrl = decoded.substring(idx + 1);
+			}
+		}
+
+		String code = codeStore.issue(userId);
+
+		String encoded = URLEncoder.encode(code, StandardCharsets.UTF_8);
+		String separator = redirectUrl.contains("?") ? "&" : "?";
+		String finalRedirect = redirectUrl + separator + "code=" + encoded;
+
+		log.info("Provider OAuth2 Redirect Url: {}", finalRedirect);
+
+		httpRequestContext.sendRedirect(finalRedirect);
+	}
+}

--- a/backend/src/main/java/com/back/global/security/oauth/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/back/global/security/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,87 @@
+package com.back.global.security.oauth;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.back.api.auth.service.SocialAuthService;
+import com.back.domain.auth.entity.ProviderType;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserRole;
+import com.back.global.security.SecurityUser;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+	private final SocialAuthService socialAuthService;
+
+	@Transactional
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2User oAuth2User = super.loadUser(userRequest);
+
+		Map<String, Object> attributes = oAuth2User.getAttributes();
+
+		log.debug("Kakao attributes={}", attributes);
+
+		// 1) properties.nickname (구버전/일반)
+		String nickname = null;
+		Object propsObj = attributes.get("properties");
+		if (propsObj instanceof Map<?, ?> props) {
+			Object nn = props.get("nickname");
+			if (nn != null)
+				nickname = nn.toString();
+		}
+
+		// 2) kakao_account.profile.nickname (신규/권장 구조)
+		if (nickname == null) {
+			Object accObj = attributes.get("kakao_account");
+			if (accObj instanceof Map<?, ?> acc) {
+				Object profileObj = acc.get("profile");
+				if (profileObj instanceof Map<?, ?> profile) {
+					Object nicknameObj = profile.get("nickname");
+					if (nicknameObj != null)
+						nickname = nicknameObj.toString();
+				}
+			}
+		}
+
+		if (nickname == null || nickname.isBlank()) {
+			log.error("Kakao nickname is missing");
+			throw new OAuth2AuthenticationException("Kakao nickname is missing");
+		}
+
+		String kakaoId = oAuth2User.getName();
+
+		User user = socialAuthService.modifyOrJoin(kakaoId, nickname, "", ProviderType.KAKAO);
+
+		Collection<GrantedAuthority> authorities =
+			List.of(new SimpleGrantedAuthority("ROLE_NORMAL"));
+
+		String userPassword = (user.getPassword() != null && !user.getPassword().isEmpty())
+			? user.getPassword()
+			: "password123";
+
+		return new SecurityUser(
+			user.getId(),
+			userPassword,
+			user.getNickname(),
+			UserRole.NORMAL,
+			null,
+			authorities
+		);
+	}
+}

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -3,13 +3,17 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=false
+    hikari:
+      connection-init-sql: SET SCHEMA PUBLIC
 
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create-drop
     properties:
+      hibernate:
+        default_schema: PUBLIC
       hibernate.id.optimizer.pooled.preferred: false
   flyway:
     enabled: false

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -39,7 +39,27 @@ spring:
     baseline-description: "baseline existing schema"
     locations: classpath:db/migration
 
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
+            scope: profile_nickname, profile_image
+            client-name: Kakao
+            authorization-grant-type: authorization_code
+            redirect-uri: '{baseUrl}/login/oauth2/code/kakao'
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
 server:
+  forward-headers-strategy: native
   tomcat:
     basedir: .
     # DoS 공격 방지: POST 요청 크기 제한 (Spring Boot 3.x)

--- a/backend/src/main/resources/db/migration/V20260103_00__alter_users_table.sql
+++ b/backend/src/main/resources/db/migration/V20260103_00__alter_users_table.sql
@@ -1,0 +1,67 @@
+/* =========================================================
+ * users - provider / email 정책 반영
+ * ========================================================= */
+
+/* 1) provider_type, provider_id 컬럼 추가 */
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS provider_type VARCHAR(50);
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS provider_id VARCHAR(255);
+
+/* 2) 기존 row → provider_type = 'LOCAL' */
+UPDATE users
+SET provider_type = 'LOCAL'
+WHERE provider_type IS NULL;
+
+
+/* 3) provider_type 기본값 + NOT NULL */
+ALTER TABLE users
+    ALTER COLUMN provider_type SET DEFAULT 'LOCAL';
+
+ALTER TABLE users
+    ALTER COLUMN provider_type SET NOT NULL;
+
+
+/* =========================================================
+ * email partial unique
+ * ========================================================= */
+
+/* 4) 기존 email UNIQUE 인덱스 제거 */
+DO
+$$
+    DECLARE
+        idx_name text;
+    BEGIN
+        SELECT i.relname
+        INTO idx_name
+        FROM pg_class t
+                 JOIN pg_index ix ON t.oid = ix.indrelid
+                 JOIN pg_class i ON i.oid = ix.indexrelid
+                 JOIN pg_attribute a ON a.attrelid = t.oid
+        WHERE t.relname = 'users'
+          AND ix.indisunique = true
+          AND a.attname = 'email'
+          AND a.attnum = ANY (ix.indkey)
+        LIMIT 1;
+
+        IF idx_name IS NOT NULL THEN
+            EXECUTE format('DROP INDEX IF EXISTS %I', idx_name);
+        END IF;
+    END
+$$;
+
+/* 5) email IS NOT NULL 인 경우만 유니크 */
+CREATE UNIQUE INDEX IF NOT EXISTS uk_users_email_not_null
+    ON users (email)
+    WHERE email IS NOT NULL;
+
+
+/* =========================================================
+ * provider unique (소셜 계정만)
+ * ========================================================= */
+
+/* 6) 소셜 계정에 대해서만 (provider_type, provider_id) 유니크 */
+CREATE UNIQUE INDEX IF NOT EXISTS uk_users_provider_social
+    ON users (provider_type, provider_id)
+    WHERE provider_type <> 'LOCAL';


### PR DESCRIPTION
## 📌 개요
- 카카오 회원가입/로그인 추가

---

## ✨ 작업 내용
- 카카오 회원가입/로그인 추가
- `CustomOAuth2AuthorizationRequestResolver` 추가: 소셜로그인을 요청할 때, 실행됨. 요청 state를 커스터마이징하여 로그인 성공 시 커스텀한 값으로 부터 원하는 값 추출
- `CustomOAuth2LoginSuccessHandler` 추가: 소셜로그인 성공 시 실행. 1회용 코드를 생성하여 프론트 리다이렉트 URL로 반환.
- `CustomOAuth2UserService` 추가: 소셜로그인 사용자 정보 저장.
- 마이그레이션 파일 추가: users 테이블 수정 -> provider_id, provider_type 컬럼 추가. email 컬럼 not null 삭제 (사업자 등록번호 없으면 이메일 정보 받는 것 불가능).
- 테스트 코드 추가

---

## 🔗 관련 이슈
- close #282   

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
