### PR TITLE
[fix] 비밀번호 인증 오류 해결

### DIFF
--- a/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -44,11 +44,11 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 		"/api/v1/auth/login",
 		"/api/v1/auth/signup",
 		"/api/v1/tickets/entry/verify",
-		"/api/v1/auth/oauth/exchange"
+		"/api/v1/auth/oauth/exchange",
+		"/api/v1/auth/logout"
 	);
 
 	private static final Set<String> AUTH_PREFIX_WHITELIST = Set.of(
-		"/api/v1/auth/",
 		"/oauth2/",
 		"/login/oauth2/"
 	);


### PR DESCRIPTION
## 📌 개요
- "/api/v1/auth/logout\", 해당 API는 인증이 필요한 API인데 AUTH_PREFIX_WHITELIST안에서 auth api를 모두 인증이 필요없는 API로 추가해서 문제가 발생하였습니다.
- 따라서 AUTH_PREFIX_WHITELIST 안에 auth 를 제거하고, AUTH_EXACT_WHITELIST에 인증이 필요없는 API를 명시적으로 작성하였습니다.

---

## ✨ 작업 내용
- 개요와 동일

---

## 🔗 관련 이슈
- close #346

---

## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
