### PR TITLE
[refactor] 카카오 이메일 동의 추가

### DIFF
--- a/backend/src/main/java/com/back/api/auth/service/SocialAuthService.java
+++ b/backend/src/main/java/com/back/api/auth/service/SocialAuthService.java
@@ -25,7 +25,7 @@ public class SocialAuthService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
 
-	public User join(String providerId, String nickname, String password, ProviderType providerType) {
+	public User join(String providerId, String nickname, String password, String email, ProviderType providerType) {
 		if (userRepository.existsByNickname(nickname)) {
 			throw new ErrorException(AuthErrorCode.ALREADY_EXIST_NICKNAME);
 		}
@@ -34,7 +34,7 @@ public class SocialAuthService {
 		String encodedPassword = passwordEncoder.encode(raw);
 
 		User user = User.builder()
-			.email(null)
+			.email(email)
 			.nickname(nickname)
 			.fullName(nickname)
 			.password(encodedPassword)
@@ -47,11 +47,12 @@ public class SocialAuthService {
 		return userRepository.save(user);
 	}
 
-	public User modifyOrJoin(String providerId, String nickname, String password, ProviderType providerType) {
+	public User modifyOrJoin(String providerId, String nickname, String password, String email,
+		ProviderType providerType) {
 		User user = userRepository.findByProviderId(providerId).orElse(null);
 
 		if (user == null) {
-			return join(providerId, nickname, password, providerType);
+			return join(providerId, nickname, password, email, providerType);
 		}
 
 		user.update(nickname, nickname, null);

--- a/backend/src/main/java/com/back/domain/user/entity/User.java
+++ b/backend/src/main/java/com/back/domain/user/entity/User.java
@@ -47,7 +47,7 @@ public class User extends BaseEntity {
 	)
 	private Long id;
 
-	@Column(length = 100)
+	@Column(nullable = false, length = 100, unique = true)
 	private String email;
 
 	@Column(nullable = false, name = "full_name", length = 30)

--- a/backend/src/main/java/com/back/global/security/oauth/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/back/global/security/oauth/CustomOAuth2UserService.java
@@ -37,26 +37,20 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 		log.debug("Kakao attributes={}", attributes);
 
-		// 1) properties.nickname (구버전/일반)
-		String nickname = null;
-		Object propsObj = attributes.get("properties");
-		if (propsObj instanceof Map<?, ?> props) {
-			Object nn = props.get("nickname");
-			if (nn != null)
-				nickname = nn.toString();
-		}
+		String nickname = "";
+		String email = "";
 
-		// 2) kakao_account.profile.nickname (신규/권장 구조)
-		if (nickname == null) {
-			Object accObj = attributes.get("kakao_account");
-			if (accObj instanceof Map<?, ?> acc) {
-				Object profileObj = acc.get("profile");
-				if (profileObj instanceof Map<?, ?> profile) {
-					Object nicknameObj = profile.get("nickname");
-					if (nicknameObj != null)
-						nickname = nicknameObj.toString();
-				}
+		Object accObj = attributes.get("kakao_account");
+		if (accObj instanceof Map<?, ?> acc) {
+			Object profileObj = acc.get("profile");
+			if (profileObj instanceof Map<?, ?> profile) {
+				Object nicknameObj = profile.get("nickname");
+				if (nicknameObj != null)
+					nickname = nicknameObj.toString();
 			}
+
+			Object emailObj = acc.get("email");
+			email = emailObj.toString();
 		}
 
 		if (nickname == null || nickname.isBlank()) {
@@ -66,7 +60,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 		String kakaoId = oAuth2User.getName();
 
-		User user = socialAuthService.modifyOrJoin(kakaoId, nickname, "", ProviderType.KAKAO);
+		User user = socialAuthService.modifyOrJoin(kakaoId, nickname, "", email, ProviderType.KAKAO);
 
 		Collection<GrantedAuthority> authorities =
 			List.of(new SimpleGrantedAuthority("ROLE_NORMAL"));

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -49,7 +49,7 @@ spring:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
             client-authentication-method: client_secret_post
-            scope: profile_nickname, profile_image
+            scope: profile_nickname, profile_image, account_email
             client-name: Kakao
             authorization-grant-type: authorization_code
             redirect-uri: '{baseUrl}/login/oauth2/code/kakao'

--- a/backend/src/main/resources/db/migration/V20260110_01__set_not_null_and_unique_in_users_email.sql
+++ b/backend/src/main/resources/db/migration/V20260110_01__set_not_null_and_unique_in_users_email.sql
@@ -1,0 +1,5 @@
+CREATE UNIQUE INDEX IF NOT EXISTS ux_users_email
+    ON users (email);
+
+ALTER TABLE users
+    ALTER COLUMN email SET NOT NULL;


### PR DESCRIPTION
## 📌 개요
- 카카오 이메일 동의 추가

---

## ✨ 작업 내용
- application.yml 이메일 프로퍼티 추가
- OAuthCustomUserService에서 이메일 프로퍼티를 읽고, 첫 로그인 시 users 테이블에 저장
<img width="1249" height="718" alt="Screenshot 2026-01-10 at 3 52 35 PM" src="https://github.com/user-attachments/assets/3e03b820-bcf6-4d0c-aa9b-4803595cd745" />

---

## 🔗 관련 이슈
- close #325 

---


## 🧪 체크리스트
- [x] 코드에 오류 X
- [x] 테스트 코드 작성 / 통과 완료
- [x] 팀 내 코드 스타일 준수
- [x] 이슈 연결
