### PR TITLE
[hotfix] Kakao 사용자 기존 이메일이 Null인 데이터에 대한 마이그레이션 이슈 해결

### DIFF
--- a/backend/src/main/java/com/back/domain/user/entity/User.java
+++ b/backend/src/main/java/com/back/domain/user/entity/User.java
@@ -47,7 +47,7 @@ public class User extends BaseEntity {
 	)
 	private Long id;
 
-	@Column(nullable = false, length = 100, unique = true)
+	@Column(length = 100)
 	private String email;
 
 	@Column(nullable = false, name = "full_name", length = 30)

--- a/backend/src/main/resources/db/migration/V20260110_01__set_not_null_and_unique_in_users_email.sql
+++ b/backend/src/main/resources/db/migration/V20260110_01__set_not_null_and_unique_in_users_email.sql
@@ -1,5 +1,3 @@
-CREATE UNIQUE INDEX IF NOT EXISTS ux_users_email
-    ON users (email);
-
-ALTER TABLE users
-    ALTER COLUMN email SET NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS ux_users_email_not_null
+    ON users (email)
+    WHERE email IS NOT NULL;


### PR DESCRIPTION
## 📌 개요
- Kakao 사용자 기존 이메일이 Null인 데이터에 대한 마이그레이션 이슈 해결

---

## ✨ 작업 내용
- 마이그레이션 파일에서 Null이 아닌 이메일만 유니크를 설정

---

## 🧪 체크리스트
- [ ] 코드에 오류 X
- [ ] 테스트 코드 작성 / 통과 완료
- [ ] 팀 내 코드 스타일 준수
- [ ] 이슈 연결
